### PR TITLE
discussion: authn API format

### DIFF
--- a/active/0015-unified-authentication.md
+++ b/active/0015-unified-authentication.md
@@ -192,6 +192,57 @@ listeners.tcp.default {
 
 The name of this listener is `tcp:default`
 
+### Listing format
+
+For listing methods, i.e.
+
+```
+GET /authentication
+GET /listeners/:listener_id/authentication
+```
+
+we have the following response format:
+
+```javascript
+[
+  {
+    "id": authenticatorId,
+    "config": authenticatorConfig
+  },
+  ...
+]
+```
+
+For example:
+
+```javascript
+[
+  {
+    "id": "password-based:built-in-database",
+    "config":
+      {
+        "backend": "built-in-database",
+        "mechanism": "password-based",
+        ...
+        "user_id_type": "clientid"
+      },
+  },
+  {
+    "id": "jwt",
+    "config":
+      {
+        "algorithm": "hmac-based",
+        "mechanism": "jwt",
+        "secret": "emqxsecret",
+        "secret_base64_encoded": false
+        "use_jwks": false,
+        "verify_claims": {}
+      }
+  }
+]
+```
+
+
 ### Re-positioning APIs
 
 ```


### PR DESCRIPTION
This is rather a discussion than an actual proposition.

For authn API we probably want to have the following two features:
A) We want to validate and specify request and response bodies through reused config hocon schemas. This should reduce manual typing, typing errors, and inconsistencies. 
B) We want to add each authenticator `id` into the config struct when returning configs to a user in chain listings (`GET /authentication`, etc.). It is how API is implemented now, and this `id` probably makes API operations simpler for a user.

The fact is, it is quite burdensome to have both A and B without any API spec changes. Currently, to specify listing responses, we should mix in `id` field: https://github.com/emqx/emqx/blob/master/apps/emqx_authn/src/emqx_authn_api.erl#L1174

If we specify answers through Hocon schemas, we have to do the same. But hocon schemas seem not composable, i.e. we can't take `hoconsc:ref(emqx_authn_mnesia, config)` and mix the `id` field into it on the fly.
We, of course, may construct the required schemas using `emqx_authn_mnesia:fields` directly, but this doesn't look like an intended way to use schemas.

What we can do:
* Refuse A) and keep things more or less like they are now, when we artificially construct minirest request-response specs.
* Refuse B). I.e., do not mix in `id` in answers. That can complicate interactions with the API because a user will have to guess how to construct ids from mechanism + backend.
* Change response schema a bit (the variant in the PR).

What we better do? 

