### PR TITLE
doc(0040): cover gateway mountpoint and request-scoped auth

### DIFF
--- a/active/0040-trusted-client-info.md
+++ b/active/0040-trusted-client-info.md
@@ -194,8 +194,11 @@ This includes:
 * Authorization.
 * Session takeover.
 * `namespace_as_mountpoint`.
+* Gateway `mountpoint` templates.
 * Multi-tenancy namespace and quota checks.
 * Limiter adjustment context.
+
+Like `namespace_as_mountpoint`, a gateway `mountpoint` template resolves placeholders such as `${clientid}` and `${username}` from `ClientInfo`, so it must render from the trusted projection. Otherwise the mountpoint prefix is built from an unverified attribute.
 
 ### Related Issues Addressed
 
@@ -267,7 +270,7 @@ The initial consumers of trusted attributes are the following:
 | --- | --- | --- |
 | `authorization.require_trusted_attributes` | Authorization rule and placeholder evaluation | No |
 | `multi_tenancy.require_trusted_attributes` | Namespace resolution, managed-namespace and quota checks | No |
-| `mqtt.require_trusted_attributes` | Session takeover | Yes, as `zones.<name>.mqtt.require_trusted_attributes` |
+| `mqtt.require_trusted_attributes` | Session takeover, gateway `mountpoint` rendering | Yes, as `zones.<name>.mqtt.require_trusted_attributes` |
 
 The defaults depend on `EMQX_SECURITY_PROFILE`.
 
@@ -296,5 +299,5 @@ The implementation must be completely backwards compatible. The compatibility mu
 
 ## Declined Alternatives
 
-* A separate `require_trusted_attributes` switch for each channel-level consumer (session takeover, `namespace_as_mountpoint`, limiter adjustment). All three read the same channel `ClientInfo` right after authentication, so one switch keeps the config surface small without losing a realistic remediation path.
+* A separate `require_trusted_attributes` switch for each channel-level consumer (session takeover, `namespace_as_mountpoint`, gateway `mountpoint`, limiter adjustment). They read the same channel `ClientInfo` established at authentication time, so one switch keeps the config surface small without losing a realistic remediation path.
 * Per-listener placement of `trusted_client_attributes`. Zone-level placement matches `client_attrs_init` and covers gateways and dedicated entry points through listener-to-zone binding, with less configuration.


### PR DESCRIPTION
Follow-up to #113.

The abstract of EIP 0040 lists **mountpoint** among the consumers that should share the trust boundary, but the "Hardened-Mode ClientInfo Consumers" list and the config table only cover `namespace_as_mountpoint` (the multi-tenancy feature). The per-gateway `mountpoint` template is a distinct consumer, and it stays reachable even once authorization uses the trusted projection:

* `emqx_mountpoint:replvar/2` resolves `${clientid}` and `${username}`, so a mountpoint like `coap/${clientid}/` derives the topic prefix from `ClientInfo`.
* Authorization is evaluated on the **unmounted** topic and the mountpoint is applied afterwards, so a placeholder-free rule such as `{allow, all, subscribe, ["cs/#"]}.` remains evaluable under the projection, passes, and is then mounted under a prefix built from an unverified attribute.
* In the CoAP gateway's default connectionless mode the mountpoint is rendered in `fix_mountpoint/2` while enriching the request client info, i.e. **before** authentication runs, so it comes from the claimed identity by construction.

Net effect: with authorization hardened but the mountpoint still rendered from full `ClientInfo`, the rules are protected but the namespace they are evaluated in is not. This is the residual part of emqx/emqx-dev-team-tasks#168 and emqx/emqx-dev-team-tasks#165, both already listed under "Related Issues Addressed".

The second change records that the trusted mask cannot be assumed to be channel state established once at connect time. CoAP connectionless authenticates per request and discards the enriched client info afterwards, so the mask has to be built and consumed within the request scope. An implementation that latches trusted attributes onto channel state at connect time would silently skip the default CoAP mode.

Changes are documentation only:

* Add gateway `mountpoint` templates to the hardened-mode consumer list, with a subsection explaining the ordering and the pre-authentication rendering.
* Add a subsection on request-scoped authentication.
* Widen the `mqtt.require_trusted_attributes` row to cover gateway mountpoint rendering.
* Amend the declined alternative so the channel-level grouping is stated as a configuration choice, not an assumption that every entry point has channel state.

No change to the trust model, the mask representation, or the configuration surface beyond what the existing `mqtt.require_trusted_attributes` switch already implies.
